### PR TITLE
Pilotar App Factory como Codex Plugin

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "app-factory-local",
+  "interface": {
+    "displayName": "App Factory Local"
+  },
+  "plugins": [
+    {
+      "name": "app-factory",
+      "source": {
+        "source": "local",
+        "path": "./"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    }
+  ]
+}

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -2,5 +2,24 @@
   "name": "app-factory",
   "version": "0.2.0-alpha",
   "description": "Portable AI software-development factory with planning, tool routing, UI, architecture, maintenance, verification, security and deployment skills.",
-  "skills": "./skills/"
+  "author": {
+    "name": "mcpmieda",
+    "url": "https://github.com/mcpmieda"
+  },
+  "repository": "https://github.com/mcpmieda/app-factory",
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "App Factory",
+    "shortDescription": "Plan, route, build and verify software with portable workflows.",
+    "longDescription": "A portable software-development factory for planning complete functional slices, routing work to the right agent, choosing coherent UI systems and requiring executable verification before completion.",
+    "developerName": "mcpmieda",
+    "category": "Productivity",
+    "capabilities": ["Interactive"],
+    "websiteURL": "https://github.com/mcpmieda/app-factory",
+    "defaultPrompt": [
+      "Plan a complete, verifiable application slice.",
+      "Route this software task to ChatGPT or Codex.",
+      "Review the UI approach and verification plan."
+    ]
+  }
 }

--- a/.github/workflows/validate-factory.yml
+++ b/.github/workflows/validate-factory.yml
@@ -20,3 +20,5 @@ jobs:
         run: python scripts/validate_factory.py
       - name: Validate Agent Skills constraints
         run: python scripts/validate_skills.py
+      - name: Validate Codex Plugin package
+        run: python scripts/validate_plugin.py

--- a/docs/CODEX_PLUGIN.md
+++ b/docs/CODEX_PLUGIN.md
@@ -26,7 +26,26 @@ O manifest aponta `skills` para `./skills/`, que já é a fonte portátil usada 
 
 ## Estado
 
-`0.2.0-alpha` — não considerar estável antes de teste local no Codex.
+`0.2.0-alpha` — manifest compatível com o esquema atual e marketplace local
+adicionado para o piloto da Issue #3. A promoção para estável depende da revisão
+das evidências do piloto.
+
+## Marketplace local sem cópia
+
+O arquivo `.agents/plugins/marketplace.json` aponta a entrada `app-factory`
+para `./`, isto é, a própria raiz do repositório. Assim, o host lê
+`.codex-plugin/plugin.json` e `skills/` diretamente da fonte portátil, sem criar
+`plugins/app-factory`, copiar Skills ou duplicar `core/`.
+
+Para registrar a origem em um Codex CLI que exponha os comandos de plugins:
+
+```text
+codex plugin marketplace add <raiz-do-repositorio>
+codex plugin add app-factory@app-factory-local
+```
+
+O Codex/ChatGPT Desktop precisa ser reiniciado e o smoke test deve ser feito em
+uma nova conversa para carregar a instalação atualizada.
 
 ## Teste necessário
 
@@ -35,10 +54,21 @@ Em uma fase executada no Codex/local:
 1. clonar/abrir `mcpmieda/app-factory`;
 2. validar que o plugin é reconhecido por marketplace/local install;
 3. confirmar descoberta das Skills;
-4. invocar pelo menos `app-planner`, `tool-router` e `verification`;
+4. invocar pelo menos `app-planner`, `tool-router`, `ui-builder` e `verification`;
 5. confirmar que nenhuma Skill precisa duplicar o Core;
 6. registrar incompatibilidades;
 7. somente depois promover a versão do plugin.
+
+Execute também os validadores versionados:
+
+```text
+python scripts/validate_factory.py
+python scripts/validate_skills.py
+python scripts/validate_plugin.py
+```
+
+As evidências executáveis do piloto estão em
+`research/V0.2_CODEX_PLUGIN_PILOT.md`.
 
 ## MCP e hooks
 

--- a/research/V0.2_CODEX_PLUGIN_PILOT.md
+++ b/research/V0.2_CODEX_PLUGIN_PILOT.md
@@ -1,0 +1,164 @@
+# V0.2 — Piloto do Codex Plugin
+
+Data: 2026-08-21
+
+Issue: #3
+
+Branch: `issue/3-codex-plugin-pilot`
+
+Baseline: `research/v0.2` em `1dc9f74`
+
+## História verificada
+
+A raiz do repositório deve ser reconhecida como um plugin skills-only pelo
+Codex, expor as dez Skills portáteis sem duplicar `skills/` ou `core/` e
+ativar `app-planner`, `tool-router`, `ui-builder` e `verification` em uma nova
+execução.
+
+## Ambiente
+
+- Windows 11 / PowerShell;
+- Codex CLI oficial `0.149.0`, distribuído por `@openai/codex`;
+- marketplace local `app-factory-local`;
+- manifest `.codex-plugin/plugin.json` na raiz;
+- sem MCP, hooks ou apps.
+
+A documentação oficial consultada foi
+[`Package your plugin`](https://developers.openai.com/plugins/build/plugins).
+Ela confirma o manifest `.codex-plugin/plugin.json`, `skills/` na raiz do
+plugin, marketplace local e teste em nova conversa/execução.
+
+## Baseline
+
+Antes de qualquer alteração:
+
+```text
+## issue/3-codex-plugin-pilot...origin/research/v0.2
+python scripts/validate_factory.py
+OK: 9 arquivos core e 10 Skills validados.
+python scripts/validate_skills.py
+OK: 10 Skills seguem as restrições essenciais do Agent Skills spec.
+```
+
+## Falha reproduzida
+
+### Sintoma
+
+O validador do `plugin-creator` rejeitou o manifest experimental:
+
+```text
+Plugin validation failed:
+- plugin.json field `author` must be an object
+- plugin.json field `interface` must be an object
+```
+
+Além disso, ainda não havia marketplace local para o host descobrir a raiz do
+repositório.
+
+### Causa
+
+O manifest da pesquisa V0.2 seguia o exemplo mínimo anterior, mas o esquema de
+ingestão atual exige metadados de autor e interface. O plugin também precisava
+de uma entrada de marketplace para instalação local.
+
+### Alteração
+
+- adicionados `author`, `repository` e `interface` ao manifest;
+- criado `.agents/plugins/marketplace.json` com `source.path: "./"`;
+- criado `scripts/validate_plugin.py`, sem dependências externas;
+- conectado o novo validador à GitHub Action existente;
+- atualizada a documentação do adaptador Codex.
+
+Nenhum arquivo de `core/` ou `skills/` foi copiado. Não foram adicionados MCP,
+hooks, apps, assets nem dependências de runtime.
+
+## Instalação e descoberta
+
+O marketplace e o plugin foram aceitos pelo host:
+
+```text
+codex plugin marketplace add <raiz-do-repositorio>
+Added marketplace `app-factory-local`.
+
+codex plugin add app-factory@app-factory-local
+Added plugin `app-factory` from marketplace `app-factory-local`.
+Installed plugin root: .../app-factory-local/app-factory/0.2.0-alpha
+
+app-factory@app-factory-local  installed, enabled  0.2.0-alpha
+```
+
+O cache instalado expôs os dez arquivos `skills/*/SKILL.md`. Durante o smoke
+test, a nova execução do Codex leu explicitamente:
+
+```text
+.../plugins/cache/app-factory-local/app-factory/0.2.0-alpha/skills/app-planner/SKILL.md
+.../plugins/cache/app-factory-local/app-factory/0.2.0-alpha/skills/tool-router/SKILL.md
+.../plugins/cache/app-factory-local/app-factory/0.2.0-alpha/skills/ui-builder/SKILL.md
+.../plugins/cache/app-factory-local/app-factory/0.2.0-alpha/skills/verification/SKILL.md
+```
+
+Os hashes SHA-256 da origem e do cache foram idênticos:
+
+| Skill | SHA-256 | Origem = cache |
+| --- | --- | --- |
+| `app-planner` | `FD806D0C2846F1FE7F2D1FC421A6AED4328781CFFFC4A301C2052CC0A5513B62` | sim |
+| `tool-router` | `0BF1F4B921E7205EE409B0319845178FD4A9FDEF0BBC62E438A8D021DD94230D` | sim |
+| `ui-builder` | `D40FA68B28C573D3ED745DB6EF223B5774876D36E532DAB1BCA5F929C75319A6` | sim |
+| `verification` | `FB20DCF553222769DA295063AA5492E928EB5C4F841B2356FA238D37D2AD9C93` | sim |
+
+## Smoke test das quatro Skills
+
+Prompt fictício: sistema web administrativo escolar para matrícula de alunos,
+com exigência explícita das quatro Skills e sem autorização para implementar.
+
+Resultado da nova execução:
+
+1. **Skills ativadas:** `app-planner`, `tool-router`, `ui-builder` e
+   `verification`.
+2. **Classificação:** aplicação M/relevante, com dados pessoais, autenticação,
+   banco e múltiplos fluxos.
+3. **Roteamento:** Codex para implementação e prova executável; ChatGPT pode
+   apoiar a especificação conceitual.
+4. **Bloco funcional:** gestão de matrículas com listagem, busca, criação,
+   edição, validação, persistência, duplicidade, permissões, estados e testes.
+5. **UI:** shadcn/ui como sistema único; sem mistura com HeroUI.
+6. **Verificação:** lint, typecheck, testes, build, aplicação real, browser,
+   desktop/mobile, acessibilidade, console, persistência e regressão antes de
+   declarar pronto.
+
+A execução encerrou com `turn.completed`, sem alterar arquivos.
+
+## Verificações finais
+
+```text
+python scripts/validate_factory.py
+OK: 9 arquivos core e 10 Skills validados.
+
+python scripts/validate_skills.py
+OK: 10 Skills seguem as restrições essenciais do Agent Skills spec.
+
+python scripts/validate_plugin.py
+OK: manifest, marketplace local e 10 Skills validados sem duplicação.
+
+plugin-creator/scripts/validate_plugin.py .
+Plugin validation passed: <raiz-do-repositorio>
+```
+
+## Impacto arquitetural
+
+O Core continua neutro. A única camada específica do Codex é o manifest, o
+marketplace local, sua documentação e um validador stdlib. O marketplace aponta
+para a própria raiz, portanto não existe segunda fonte de verdade.
+
+## Limitações conhecidas
+
+- o Codex/ChatGPT Desktop carrega alterações de plugin em nova conversa após
+  reinício/reinstalação; o piloto usou uma nova execução não interativa do mesmo
+  host/configuração para obter evidência reproduzível;
+- o launcher `codex.exe` da Microsoft Store permaneceu aberto sem imprimir
+  versão neste terminal; o binário oficial `0.149.0` do pacote npm foi usado;
+- dois avisos sobre ícones com `..` vieram de outro plugin instalado no ambiente;
+  a App Factory não declara ícones ou assets e não foi a origem dos avisos.
+
+Essas limitações não invalidam reconhecimento, instalação, descoberta ou
+ativação das Skills da App Factory.

--- a/scripts/validate_plugin.py
+++ b/scripts/validate_plugin.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Valida o adaptador Codex Plugin da App Factory usando apenas a stdlib."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+MANIFEST_PATH = ROOT / ".codex-plugin" / "plugin.json"
+MARKETPLACE_PATH = ROOT / ".agents" / "plugins" / "marketplace.json"
+NAME_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+SEMVER_RE = re.compile(
+    r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
+    r"(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?"
+    r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$"
+)
+
+
+def stop(message: str) -> None:
+    print(f"ERROR: {message}")
+    raise SystemExit(1)
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        stop(f"arquivo ausente: {path.relative_to(ROOT)}")
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        stop(f"JSON inválido em {path.relative_to(ROOT)}: {error}")
+    if not isinstance(payload, dict):
+        stop(f"objeto JSON esperado em {path.relative_to(ROOT)}")
+    return payload
+
+
+def non_empty_string(payload: dict[str, Any], field: str, location: str) -> str:
+    value = payload.get(field)
+    if not isinstance(value, str) or not value.strip():
+        stop(f"{location}.{field} deve ser string não vazia")
+    return value
+
+
+def validate_manifest() -> dict[str, Any]:
+    manifest = read_json(MANIFEST_PATH)
+    name = non_empty_string(manifest, "name", "plugin.json")
+    if not NAME_RE.fullmatch(name):
+        stop("plugin.json.name deve usar kebab-case")
+
+    version = non_empty_string(manifest, "version", "plugin.json")
+    if not SEMVER_RE.fullmatch(version):
+        stop("plugin.json.version deve usar SemVer estrito")
+
+    non_empty_string(manifest, "description", "plugin.json")
+    author = manifest.get("author")
+    if not isinstance(author, dict):
+        stop("plugin.json.author deve ser objeto")
+    non_empty_string(author, "name", "plugin.json.author")
+
+    skills_path = non_empty_string(manifest, "skills", "plugin.json")
+    if skills_path != "./skills/" or not (ROOT / "skills").is_dir():
+        stop("plugin.json.skills deve apontar para ./skills/ na raiz")
+
+    interface = manifest.get("interface")
+    if not isinstance(interface, dict):
+        stop("plugin.json.interface deve ser objeto")
+    for field in (
+        "displayName",
+        "shortDescription",
+        "longDescription",
+        "developerName",
+        "category",
+    ):
+        non_empty_string(interface, field, "plugin.json.interface")
+
+    capabilities = interface.get("capabilities")
+    if not isinstance(capabilities, list) or not capabilities or not all(
+        isinstance(item, str) and item.strip() for item in capabilities
+    ):
+        stop("plugin.json.interface.capabilities deve ser lista não vazia de strings")
+
+    prompts = interface.get("defaultPrompt")
+    if not isinstance(prompts, list) or not 1 <= len(prompts) <= 3:
+        stop("plugin.json.interface.defaultPrompt deve conter de 1 a 3 prompts")
+    if not all(isinstance(item, str) and 0 < len(item) <= 128 for item in prompts):
+        stop("cada defaultPrompt deve ser string não vazia de até 128 caracteres")
+
+    return manifest
+
+
+def validate_marketplace(plugin_name: str) -> None:
+    marketplace = read_json(MARKETPLACE_PATH)
+    non_empty_string(marketplace, "name", "marketplace.json")
+    entries = marketplace.get("plugins")
+    if not isinstance(entries, list):
+        stop("marketplace.json.plugins deve ser lista")
+
+    matches = [entry for entry in entries if isinstance(entry, dict) and entry.get("name") == plugin_name]
+    if len(matches) != 1:
+        stop(f"marketplace deve conter exatamente uma entrada para {plugin_name}")
+    entry = matches[0]
+    source = entry.get("source")
+    if not isinstance(source, dict) or source.get("source") != "local":
+        stop("marketplace deve usar source local")
+    if source.get("path") != "./":
+        stop("marketplace deve apontar para ./ e reutilizar a raiz sem cópia")
+
+    policy = entry.get("policy")
+    if not isinstance(policy, dict):
+        stop("marketplace policy deve ser objeto")
+    if policy.get("installation") not in {"AVAILABLE", "INSTALLED_BY_DEFAULT", "NOT_AVAILABLE"}:
+        stop("marketplace policy.installation inválida")
+    if policy.get("authentication") not in {"ON_INSTALL", "ON_USE"}:
+        stop("marketplace policy.authentication inválida")
+    non_empty_string(entry, "category", "marketplace.plugins[app-factory]")
+
+
+def main() -> int:
+    manifest = validate_manifest()
+    validate_marketplace(manifest["name"])
+    skills = sorted((ROOT / "skills").glob("*/SKILL.md"))
+    print(
+        "OK: manifest, marketplace local e "
+        f"{len(skills)} Skills validados sem duplicação."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Resumo

- atualiza o manifest experimental para o esquema atual de ingestão do Codex;
- adiciona marketplace repo-local apontando para `./`, sem copiar `skills/` ou `core/`;
- adiciona validação stdlib da camada Codex e a conecta à CI;
- registra instalação, descoberta, hashes e smoke test das quatro Skills.

## Falha e correção

O validador atual rejeitava o manifest por ausência de `author` e `interface`. O manifest recebeu somente os metadados exigidos; a arquitetura continua skills-only, sem MCP, hooks, apps ou assets.

## Evidências

- Codex CLI oficial `0.149.0` reconheceu `app-factory-local`;
- `app-factory@app-factory-local` ficou `installed, enabled`, versão `0.2.0-alpha`;
- as 10 Skills apareceram no cache do plugin;
- `app-planner`, `tool-router`, `ui-builder` e `verification` foram lidas e ativadas numa nova execução;
- os hashes SHA-256 dessas quatro Skills foram idênticos na origem e no cache;
- o smoke test classificou a aplicação, roteou para Codex, definiu bloco funcional completo, manteve um design system e exigiu validação antes de pronto.

Relatório completo: `research/V0.2_CODEX_PLUGIN_PILOT.md`.

## Testes

```text
python scripts/validate_factory.py
python scripts/validate_skills.py
python scripts/validate_plugin.py
plugin-creator/scripts/validate_plugin.py .
python -m py_compile scripts/validate_factory.py scripts/validate_skills.py scripts/validate_plugin.py
```

Também foram validados JSON, YAML, ausência de cópia aninhada e ausência de MCP/app/hooks.

## Limitações conhecidas

- o Desktop requer reinstalação/reinício e nova conversa para pickup; a prova reproduzível foi feita em nova execução não interativa usando a mesma configuração/cache do Codex;
- avisos de ícones observados pertencem a outro plugin do ambiente; a App Factory não declara assets.

Closes #3
