### PR TITLE
feat: promote validated web-admin profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,59 @@
 # Changelog
 
+## 0.4-web-admin-profile — 2026-08-21
+
+Promoção controlada dos aprendizados comprovados pelo piloto V0.3.
+
+### Promovido
+
+- criado `profiles/` como camada de defaults condicionais validados;
+- criado `profiles/web-admin/PROFILE.md`;
+- `factory-router` passa a selecionar perfil validado quando o produto corresponder claramente;
+- `app-planner` passa a aplicar defaults de perfil sem exigir decisões técnicas rotineiras do usuário;
+- `core/ENTRYPOINT.md` passa a incluir seleção de perfil;
+- shadcn promovido como base visual do perfil `web-admin`;
+- ReUI reclassificado como opcional/seletivo por componente;
+- Better Auth promovido como primeira opção quando autenticação própria for necessária;
+- Drizzle promovido como primeira opção quando persistência própria for necessária;
+- Zod, Vitest, Playwright e lint específico do Next promovidos no perfil;
+- SQLite/better-sqlite3 mantido como alternativa local/teste;
+- Biome mantido como complemento opcional.
+
+### Guardrails aprendidos
+
+- lockfile/package manager devem ser reproduzíveis entre desenvolvimento e CI;
+- CI deve usar instalação limpa (`npm ci` ou equivalente), não mascarar inconsistência com instalação permissiva;
+- typecheck/testes não podem depender silenciosamente de artefatos gerados previamente;
+- operações destrutivas relevantes devem ter proteção de domínio e teste E2E quando apropriado;
+- código vindo de registry deve ser auditado e módulos/dependências não usados removidos.
+
+### Próxima fase
+
+Gerar um starter `web-admin` limpo a partir do perfil validado e provar a Factory criando um segundo aplicativo do zero. O piloto V0.3 permanece como evidência, não como template copiado cegamente.
+
+## 0.3-web-admin-pilot — 2026-08-21
+
+Piloto real de aplicação administrativa da App Factory.
+
+### Validado
+
+- aplicação Next/React/TypeScript com Tailwind e shadcn;
+- Better Auth + Drizzle + SQLite local;
+- Zod, Vitest e Playwright;
+- Data Grid real do ReUI;
+- autenticação, CRUD, busca, filtros, desativação, reativação e exclusão segura;
+- desktop/mobile e persistência após reload;
+- CI reproduzível em checkout limpo;
+- audit sem vulnerabilidades high/critical no gate;
+- revisão ChatGPT após execução Codex.
+
+### Aprendizados
+
+- ReUI agrega valor em componentes avançados, mas exige auditoria pós-registry;
+- SQLite não deve virar default universal de produção;
+- Biome não substituiu o lint específico do Next neste piloto;
+- teste local isolado não provou reprodutibilidade: o GitHub CI encontrou lockfile inconsistente e dependência do typecheck em `.next`, ambos corrigidos antes do merge.
+
 ## 0.2.1-alpha — 2026-08-21
 
 Ativação automática da App Factory por intenção de software.
@@ -25,9 +79,9 @@ Pesquisa estruturada e validação do primeiro adaptador real da App Factory.
 - triagem de 58 repositórios e ferramentas;
 - classificação ADOTAR / INSPIRAR / DESCARTAR;
 - shortlist P0/P1/P2;
-- confirmação de shadcn + ReUI como eixo preferencial do perfil `web-admin`;
+- confirmação inicial de shadcn + ReUI como eixo candidato do perfil `web-admin`;
 - HeroUI mantido como perfil alternativo;
-- Better Auth + Drizzle + Zod definidos como candidatos de piloto, não defaults universais;
+- Better Auth + Drizzle + Zod definidos como candidatos de piloto;
 - Playwright definido como forte candidato E2E;
 - Spec Kit incorporado como referência para fluxo spec-driven proporcional à escala.
 
@@ -50,10 +104,6 @@ Pesquisa estruturada e validação do primeiro adaptador real da App Factory.
 - 10 Skills foram descobertas e 4 exercitadas em smoke test;
 - hashes origem/cache das Skills exercitadas foram idênticos;
 - nenhuma duplicação de `skills/` ou `core/` foi necessária.
-
-### Próxima fase
-
-V0.3: piloto `web-admin` da Issue #4 para validar a stack candidata em aplicação real antes de promover defaults da V1.
 
 ## 0.1-bootstrap — 2026-08-20
 
@@ -83,7 +133,3 @@ Primeiro bootstrap da App Factory.
 ### Origem
 
 Esta versão consolida decisões das conversas de planejamento e filtra os princípios úteis da pasta histórica `Boas práticas/`.
-
-### Próxima fase
-
-V0.2: pesquisa estruturada de referências externas antes de congelar o primeiro starter.

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -4,41 +4,50 @@
 
 ## Objetivo atual
 
-Validar a App Factory em uma aplicação web administrativa real antes de promover tecnologias e padrões a defaults da V1.
+Transformar os aprendizados validados do piloto V0.3 em um perfil `web-admin` reutilizável e, depois, gerar um starter limpo para um segundo teste do zero.
 
 ## Estado
 
-- fase: `V0.3 — piloto web-admin com bloqueadores de revisão corrigidos`;
-- baseline oficial: `main` após merge do PR #2 (`d917a891b364502d01b3644431f4b5df1d4d588c`);
+- fase: `V0.4 — promoção do perfil web-admin`;
+- baseline oficial: `main` após merge do PR #6 (`2e786d39505cfdbc766f6481535cb65413d2b735`);
 - V0.1 bootstrap: concluída;
 - V0.2 pesquisa: concluída e integrada;
+- V0.2.1 entry router: concluído e integrado;
 - Issue #3 / Codex Plugin: concluída e revisada;
-- adaptador Codex: validado em piloto real;
-- 10 Skills: validadas e descobertas pelo Codex;
-- CI: valida estrutura, Agent Skills e Codex Plugin.
+- V0.3 piloto web-admin: concluído, revisado, CI reproduzível e integrado;
+- Issues #4 e #8: concluídas;
+- CI: valida Core/Skills/plugin e o piloto web-admin em checkout limpo.
 
 ## Decisões vigentes
 
 - Core permanece neutro e portátil;
 - Codex usa adaptador/plugin fino sem duplicar Skills;
+- intenção de software ativa a Factory automaticamente;
 - processo varia por escala XS/S/M/L;
-- `shadcn + ReUI` é candidato preferencial do perfil admin;
-- HeroUI é perfil alternativo;
-- Better Auth + Drizzle + Zod foram aprovados para promoção ao perfil web-admin, ainda não são defaults universais;
-- Playwright foi aprovado como default E2E do perfil;
-- Spec Kit deve ser usado proporcionalmente à escala;
-- starters devem ser componíveis, sem serviços opcionais impostos.
+- Factory pode selecionar perfil validado em `profiles/` após entender o produto;
+- perfil não é dogma e módulos opcionais só entram quando necessários;
+- no perfil `web-admin`, shadcn é a base visual;
+- ReUI é opcional/seletivo por componente avançado;
+- HeroUI é perfil visual alternativo;
+- Better Auth é primeira opção condicional quando o projeto exige autenticação própria;
+- Drizzle é primeira opção condicional quando o projeto exige persistência própria;
+- provider de banco é escolhido pelo ambiente; SQLite/better-sqlite3 fica local/teste salvo requisito real;
+- Zod, Vitest, Playwright e lint oficial do Next foram promovidos para o perfil;
+- Biome fica opcional/complementar;
+- Spec Kit continua proporcional à escala;
+- starters permanecem componíveis, sem serviços opcionais impostos;
+- instalação limpa e CI reproduzível são gates, não apenas testes locais.
 
 ## Trabalho atual
 
-- bloco: Issue #8 — corrigir reprodutibilidade e prova do ciclo destrutivo no draft PR #6;
-- ambiente recomendado: Codex;
-- motivo: exige scaffold real, dependências, banco, autenticação, build, testes e navegador;
-- regra: construir o piloto de forma isolada e não alterar o Core para acomodar resultados locais sem evidência.
+- bloco: promover `profiles/web-admin/PROFILE.md` e ligar o perfil ao `factory-router`/`app-planner`;
+- ambiente recomendado: ChatGPT + GitHub;
+- motivo: é consolidação de arquitetura/documentação já comprovada, sem necessidade de ambiente local neste bloco;
+- branch: `promote/web-admin-profile-v0.4`.
 
 ## Próxima ação
 
-Revisar os checks finais do draft PR #6 após a correção da Issue #8. Confirmar `npm ci` reproduzível e o Playwright ampliado antes de qualquer promoção ao Core; não fazer merge automático.
+Após CI/revisão e merge da V0.4, criar uma Issue para Codex gerar um starter `web-admin` limpo a partir do perfil, sem copiar cegamente `pilots/web-admin/`, e validar um segundo app do zero.
 
 ## Handoff
 
@@ -46,6 +55,7 @@ Outro agente deve começar por:
 
 1. `AGENTS.md`;
 2. este `PROJECT_STATE.md`;
-3. `research/V0.3_WEB_ADMIN_PILOT.md`;
-4. `pilots/web-admin/README.md`;
-5. Issues #4/#8 e o draft PR #6.
+3. `profiles/web-admin/PROFILE.md`;
+4. `research/V0.3_WEB_ADMIN_PILOT.md`;
+5. `starters/web-admin/README.md`;
+6. PR da branch `promote/web-admin-profile-v0.4` quando existir.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Transformar uma ideia em software funcional usando um método reutilizável que 
 A App Factory não é um prompt gigante. Ela combina:
 
 - entrada universal por intenção de software;
+- seleção automática de perfil validado quando aplicável;
 - `AGENTS.md` como mapa operacional;
 - Core curto e modular;
 - Skills especializadas carregadas conforme a tarefa;
@@ -26,9 +27,11 @@ O usuário pode começar somente com o resultado, por exemplo:
 
 > Quero criar um sistema de patrimônio para a escola.
 
-Ele não precisa dizer "use a App Factory", escolher framework, descobrir Skills ou decidir sozinho entre ChatGPT e Codex.
+Ele não precisa dizer "use a App Factory", escolher framework, descobrir Skills, selecionar perfil ou decidir sozinho entre ChatGPT e Codex.
 
-Quando o plugin estiver instalado, `factory-router` é a Skill universal que reconhece intenção de desenvolvimento e aciona o processo adequado. Quando um projeto novo ganha repositório, ele recebe `templates/project/AGENTS.md`, que mantém o vínculo com a Factory para futuras conversas e outros agentes.
+A Factory deve reconhecer a intenção, entender o produto, classificar escala/risco, selecionar um perfil já validado quando existir e fazer as escolhas técnicas rotineiras por evidência.
+
+Para o exemplo de patrimônio, o roteador pode reconhecer o perfil `web-admin` e usar seus defaults comprovados, ativando autenticação, banco ou ReUI somente se o produto realmente precisar.
 
 ## Princípio central
 
@@ -37,17 +40,47 @@ A IA deve trabalhar para atingir o objetivo do usuário, não apenas obedecer li
 ## Comece por aqui
 
 1. `AGENTS.md` — mapa para agentes.
-2. `core/ENTRYPOINT.md` — ativação automática por intenção.
+2. `core/ENTRYPOINT.md` — ativação automática por intenção e seleção de perfil.
 3. `skills/factory-router/SKILL.md` — roteador universal.
-4. `APP_FACTORY_PLAN.md` — visão, fases e decisões já tomadas.
-5. `core/PRINCIPLES.md` — princípios universais.
-6. `core/HUMAN_INTERACTION.md` — o que a IA faz sozinha e o que depende do usuário.
-7. `core/PROJECT_SCALE.md` — profundidade XS/S/M/L.
-8. `core/TASK_ROUTER.md` — quando usar ChatGPT, Codex ou outro agente.
-9. `core/WORKFLOW.md` — ciclo de projeto novo e manutenção.
-10. `core/DEFINITION_OF_DONE.md` — como provar que terminou.
-11. `PORTABILITY.md` — continuidade entre agentes.
-12. `docs/CODEX_PLUGIN.md` — adaptador Codex validado em piloto.
+4. `profiles/README.md` — perfis validados por classe de software.
+5. `profiles/web-admin/PROFILE.md` — primeiro perfil validado.
+6. `APP_FACTORY_PLAN.md` — visão, fases e decisões.
+7. `core/PRINCIPLES.md` — princípios universais.
+8. `core/HUMAN_INTERACTION.md` — o que a IA faz sozinha e o que depende do usuário.
+9. `core/PROJECT_SCALE.md` — profundidade XS/S/M/L.
+10. `core/TASK_ROUTER.md` — quando usar ChatGPT, Codex ou outro agente.
+11. `core/WORKFLOW.md` — ciclo de projeto novo e manutenção.
+12. `core/DEFINITION_OF_DONE.md` — como provar que terminou.
+13. `PORTABILITY.md` — continuidade entre agentes.
+14. `docs/CODEX_PLUGIN.md` — adaptador Codex validado em piloto.
+
+## Perfis
+
+### web-admin — validado V0.4
+
+Para sistemas administrativos, CRUDs, dashboards e ferramentas internas.
+
+Base comprovada:
+
+- TypeScript;
+- Next.js App Router;
+- React;
+- Tailwind;
+- shadcn como base visual;
+- Zod;
+- Vitest;
+- Playwright;
+- ESLint/configuração oficial do Next.
+
+Módulos condicionais comprovados:
+
+- Better Auth quando identidade/login forem necessários;
+- Drizzle quando houver persistência própria;
+- ReUI seletivo para componentes avançados;
+- SQLite/better-sqlite3 apenas como alternativa local/teste;
+- Biome opcional/complementar.
+
+O perfil completo está em `profiles/web-admin/PROFILE.md`.
 
 ## Estrutura atual
 
@@ -57,34 +90,13 @@ app-factory/
 ├── APP_FACTORY_PLAN.md
 ├── PORTABILITY.md
 ├── .codex-plugin/
-│   └── plugin.json
 ├── .agents/plugins/
-│   └── marketplace.json
 ├── core/
-│   ├── ENTRYPOINT.md
-│   ├── PRINCIPLES.md
-│   ├── HUMAN_INTERACTION.md
-│   ├── PROJECT_SCALE.md
-│   ├── TASK_ROUTER.md
-│   ├── WORKFLOW.md
-│   ├── RISK_MODEL.md
-│   └── DEFINITION_OF_DONE.md
 ├── skills/
-│   ├── factory-router/
-│   ├── app-planner/
-│   ├── architecture/
-│   ├── tool-router/
-│   ├── ui-builder/
-│   ├── maintenance/
-│   ├── database/
-│   ├── debugging/
-│   ├── security-review/
-│   ├── verification/
-│   └── deployment/
+├── profiles/
+│   └── web-admin/
 ├── policies/
 ├── templates/
-│   └── project/
-│       └── AGENTS.md
 ├── starters/
 │   └── web-admin/
 ├── ui/
@@ -97,24 +109,28 @@ app-factory/
 
 ## Decisões consolidadas
 
-- A intenção de criar/evoluir software deve acionar a Factory sem palavra-chave manual.
+- A intenção de criar/evoluir software aciona a Factory sem palavra-chave manual.
+- A Factory pode selecionar um perfil validado automaticamente depois de entender o produto.
+- Perfil não é dogma: requisitos locais têm precedência e módulos opcionais só entram quando necessários.
 - GitHub é a fonte técnica de verdade.
-- Novos projetos recebem um `AGENTS.md` que aponta de volta para a Factory sem duplicar todo o Core.
-- A Factory orienta o usuário sobre quando usar ChatGPT e quando usar Codex.
+- Novos projetos recebem um `AGENTS.md` que aponta para a Factory sem duplicar todo o Core.
+- A Factory orienta quando usar ChatGPT e quando usar Codex.
 - ChatGPT é preferido para produto, pesquisa, arquitetura conceitual, documentação e revisão.
 - Codex é preferido para execução local, múltiplos arquivos, terminal, dependências, testes, build, navegador, debugging e migrations.
 - A Factory minimiza trabalho manual do usuário e toma decisões técnicas rotineiras autonomamente.
-- A profundidade do processo cresce com escala e risco; projeto pequeno não recebe ritual de sistema crítico.
-- Sistemas administrativos avaliam primeiro shadcn + ReUI; HeroUI é perfil alternativo, não mistura obrigatória.
+- A profundidade do processo cresce com escala e risco.
+- No perfil `web-admin`, shadcn é a base e ReUI é seletivo por componente.
+- HeroUI continua perfil visual alternativo, não mistura automática.
 - Pesquisar e reutilizar antes de construir do zero.
 - Escopo fechado significa fatia funcional verificável, não microtarefas.
 - Baseline/diff/rollback continuam centrais para manutenção de sistemas existentes.
-- Regras fortes devem virar testes, scripts ou CI quando isso reduzir risco de forma concreta.
+- Regras fortes devem virar testes, scripts ou CI quando isso reduzir risco.
 - O núcleo permanece portátil entre agentes.
 - A integração Codex foi validada como plugin fino, reutilizando as mesmas Skills sem duplicação.
+- Teste local não substitui instalação limpa e CI reproduzível.
 
 ## Estado
 
-Versão de trabalho: `0.3-web-admin-pilot`
+Versão de trabalho: `0.4-web-admin-profile`
 
-A pesquisa avaliou 58 referências, o adaptador Codex passou por piloto real e o piloto `web-admin` da Issue #4 foi implementado com autenticação, banco, CRUD, testes e evidência de navegador. O experimento aguarda revisão em draft PR antes de qualquer promoção de defaults da V1.
+O piloto V0.3 foi integrado após revisão e CI reproduzível. A V0.4 promove somente os aprendizados comprovados para um perfil `web-admin` condicional. O próximo gate é gerar um starter limpo a partir do perfil e validar um segundo app do zero antes de declarar V1 estável.

--- a/core/ENTRYPOINT.md
+++ b/core/ENTRYPOINT.md
@@ -24,7 +24,7 @@ Também ative quando o usuário expressar apenas o resultado, por exemplo:
 - "Quero automatizar este processo."
 - "Continue o projeto X."
 
-O usuário não precisa conhecer stack, arquitetura, Skills ou agentes.
+O usuário não precisa conhecer stack, arquitetura, perfis, Skills ou agentes.
 
 ## Primeira passagem obrigatória
 
@@ -32,12 +32,21 @@ O usuário não precisa conhecer stack, arquitetura, Skills ou agentes.
 2. Determine se é projeto novo, evolução, manutenção, bug, automação ou pesquisa técnica.
 3. Se existir repositório/projeto, leia primeiro o estado versionado (`AGENTS.md`, `PROJECT_STATE.md`, produto/arquitetura e diff relevante).
 4. Classifique a escala em `core/PROJECT_SCALE.md`.
-5. Aplique risco em `core/RISK_MODEL.md`.
-6. Escolha o ambiente com `core/TASK_ROUTER.md`.
-7. Carregue apenas as Skills necessárias.
-8. Pesquise solução existente antes de construir equivalente do zero quando houver ganho real.
-9. Defina o próximo bloco funcional completo.
-10. Execute imediatamente tudo que o ambiente atual permitir com segurança.
+5. Verifique `profiles/` e selecione um perfil validado quando o produto corresponder claramente; não force perfil quando nenhum servir.
+6. Aplique risco em `core/RISK_MODEL.md`.
+7. Escolha o ambiente com `core/TASK_ROUTER.md`.
+8. Carregue apenas as Skills necessárias.
+9. Pesquise solução existente antes de construir equivalente do zero quando houver ganho real.
+10. Defina o próximo bloco funcional completo.
+11. Execute imediatamente tudo que o ambiente atual permitir com segurança.
+
+## Regra de perfis
+
+Perfis transformam evidência real em defaults condicionais. Eles não substituem entendimento do produto.
+
+Exemplo: um sistema de patrimônio com login, CRUD, filtros e dashboard provavelmente corresponde a `profiles/web-admin/PROFILE.md`. A Factory pode usar os defaults comprovados desse perfil, mas só ativa autenticação, banco, ReUI ou outros módulos quando o produto realmente precisar.
+
+Requisitos específicos do projeto têm precedência sobre defaults do perfil, salvo conflito de segurança.
 
 ## Regra de GitHub
 
@@ -50,6 +59,7 @@ Quando o projeto ganhar repositório próprio, grave nele pelo menos:
 - `AGENTS.md` com vínculo explícito à App Factory;
 - `PROJECT_STATE.md`;
 - artefatos de produto/arquitetura proporcionais à escala;
+- perfil selecionado e desvios relevantes quando aplicável;
 - testes/CI quando aplicáveis.
 
 ### Projeto existente
@@ -77,6 +87,7 @@ O agente deve saber, mesmo que não exponha todos os detalhes:
 
 - modo do trabalho;
 - escala;
+- perfil selecionado, se houver;
 - risco;
 - Skill(s) necessárias;
 - ChatGPT, Codex ou outro ambiente recomendado;

--- a/profiles/README.md
+++ b/profiles/README.md
@@ -1,0 +1,32 @@
+# Project Profiles
+
+Profiles convert validated evidence into conditional defaults for recurring classes of software.
+
+A profile is not a universal stack. It is a tested starting point the Factory may select automatically after understanding the product.
+
+## Selection rule
+
+1. understand the problem first;
+2. choose a profile only when the product clearly fits;
+3. apply profile defaults conditionally;
+4. local project requirements override generic profile defaults;
+5. avoid installing optional modules without a demonstrated need.
+
+## Validated profiles
+
+### `web-admin`
+
+Use for administrative systems, CRUDs, dashboards, internal tools and data-oriented management applications.
+
+See `profiles/web-admin/PROFILE.md`.
+
+## Planned profiles
+
+- `website`;
+- `web-app` general-purpose;
+- `chrome-extension`;
+- `automation`;
+- API/backend;
+- mobile/desktop when evidence is available.
+
+A planned profile must not be treated as validated until it passes a real pilot and review gates comparable to its risk.

--- a/profiles/web-admin/PROFILE.md
+++ b/profiles/web-admin/PROFILE.md
@@ -1,0 +1,144 @@
+# Web Admin Profile
+
+Status: `validated-v0.4`
+
+Este perfil consolida somente decisões comprovadas pelo piloto V0.3. Ele não é uma stack universal para todo software.
+
+## Quando usar
+
+Aplicações administrativas, CRUDs, dashboards, ferramentas internas e sistemas de gestão com UI orientada a dados.
+
+## Base padrão
+
+Instalar por padrão neste perfil, salvo restrição real do projeto:
+
+- TypeScript;
+- Next.js App Router;
+- React;
+- Tailwind CSS;
+- shadcn/ui como base do design system;
+- Zod para validação/contratos;
+- Vitest para testes unitários e de integração adequados;
+- Playwright para o fluxo E2E crítico;
+- ESLint/configuração oficial do Next para lint específico da stack.
+
+## Módulos ativados por necessidade
+
+### Autenticação
+
+Quando o produto exigir login/identidade própria, preferir **Better Auth** como primeira opção do perfil.
+
+Não instalar auth em projeto que não precisa de identidade.
+
+Regras:
+- validar sessão no servidor para operações protegidas;
+- não confiar apenas em proteção visual/cliente;
+- provider e estratégia de sessão devem considerar o ambiente real.
+
+### Persistência
+
+Quando o produto possuir dados próprios, preferir **Drizzle** como primeira opção do perfil.
+
+O banco não é fixado universalmente. Escolher provider conforme deploy, volume, concorrência, custo e operação.
+
+- SQLite/better-sqlite3: alternativa local/teste e aplicações realmente adequadas a arquivo local;
+- produção/serverless: escolher provider apropriado ao ambiente antes de gerar a arquitetura definitiva.
+
+### ReUI
+
+**Opcional e seletivo.** Usar quando um componente avançado, como Data Grid, filtros complexos, Kanban, calendário ou outro padrão administrativo, reduzir trabalho de forma clara.
+
+Após instalar via registry:
+- revisar todos os arquivos adicionados;
+- remover módulos/dependências não usados;
+- executar lint/typecheck/testes;
+- adaptar somente o necessário às regras atuais do React/stack.
+
+Não tratar ReUI como segunda base visual paralela ao shadcn.
+
+### Biome
+
+Opcional como formatter/check complementar. Não substituir automaticamente lint específico do framework quando a cobertura não for equivalente.
+
+### Formulários
+
+Começar com a solução mais simples suportada pelo framework/Server Actions.
+
+Adicionar React Hook Form, TanStack Form ou equivalente somente quando complexidade de formulário, validação cliente, campos dinâmicos ou UX justificarem.
+
+### Estado/cache no cliente
+
+Não adicionar TanStack Query, Zustand ou equivalente por padrão. Usar somente quando cache, sincronização cliente, optimistic updates ou estado compartilhado trouxerem ganho real.
+
+### Observabilidade
+
+Sentry/OpenTelemetry e similares entram conforme criticidade, produção e necessidade operacional. Não fazem parte do bootstrap mínimo.
+
+## UI
+
+- shadcn é a fundação;
+- ReUI é uma fonte de componentes avançados, não um design system concorrente obrigatório;
+- HeroUI é perfil alternativo para produtos em que seu sistema visual seja claramente mais adequado;
+- não misturar HeroUI neste perfil apenas por estética.
+
+## Arquitetura padrão
+
+Preferir Server Components/Server Actions e estado local simples quando suficientes.
+
+Adicionar camadas somente quando o comportamento do produto exigir.
+
+Estrutura inicial sugerida:
+
+```text
+src/
+├── app/
+├── components/
+│   ├── ui/
+│   └── layout/
+├── features/
+│   └── <feature>/
+│       ├── components/
+│       ├── schemas/
+│       ├── data/
+│       └── tests/
+├── lib/
+├── config/
+└── types/
+```
+
+A estrutura pode ser simplificada para apps menores.
+
+## Gate mínimo de qualidade
+
+Quando os scripts existirem:
+
+1. instalação reproduzível (`npm ci` ou equivalente);
+2. setup/migrations/seed quando aplicável;
+3. format check;
+4. lint;
+5. typecheck;
+6. testes unit/integration relevantes;
+7. build;
+8. auditoria de dependências proporcional ao risco;
+9. Playwright do fluxo crítico;
+10. desktop e viewport móvel;
+11. console sem erro relevante.
+
+## Reprodutibilidade
+
+- package manager/linha relevante deve ser consistente entre lockfile, desenvolvimento e CI;
+- CI deve usar instalação limpa, não instalação permissiva para esconder lockfile inconsistente;
+- typecheck e testes não podem depender silenciosamente de artefatos gerados por execução anterior.
+
+## Segurança mínima
+
+- segredos fora do Git;
+- validação server-side para mutações;
+- autorização no servidor;
+- operações destrutivas protegidas por estado/regra de negócio e confirmação quando apropriado;
+- migrations versionadas;
+- excluir permanentemente apenas quando o domínio permitir e o comportamento estiver testado.
+
+## Evidência de origem
+
+Perfil derivado de `research/V0.3_WEB_ADMIN_PILOT.md` e do PR #6, que passaram por execução local, revisão ChatGPT e GitHub Actions reproduzível antes da promoção.

--- a/skills/app-planner/SKILL.md
+++ b/skills/app-planner/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: app-planner
-description: Planeja um novo aplicativo ou uma evolução relevante, transformando a ideia do usuário em escopo, arquitetura inicial, riscos, critérios de sucesso e blocos funcionais sem exigir decisões técnicas desnecessárias do usuário.
+description: Planeja um novo aplicativo ou uma evolução relevante, transformando a ideia do usuário em escopo, perfil de projeto quando aplicável, arquitetura inicial, riscos, critérios de sucesso e blocos funcionais sem exigir decisões técnicas desnecessárias do usuário.
 ---
 
 # App Planner
@@ -14,18 +14,20 @@ Use quando a tarefa começa como ideia, problema, novo sistema ou grande evoluç
 3. Separe requisito real de solução sugerida.
 4. Pesquise solução existente quando isso puder eliminar trabalho desnecessário.
 5. Defina o menor produto que entrega valor real sem reduzir artificialmente a visão final.
-6. Escolha stack apenas depois de entender o problema.
-7. Divida execução em blocos funcionais completos.
-8. Para cada bloco, defina critérios observáveis de conclusão.
-9. Use `core/TASK_ROUTER.md` para orientar onde cada fase deve acontecer.
-10. Registre decisões permanentes no repositório, não apenas no chat.
+6. Verifique se existe perfil validado em `profiles/` que corresponda claramente ao produto.
+7. Quando houver perfil adequado, use seus defaults como ponto de partida e ative apenas módulos necessários; requisitos locais têm precedência.
+8. Quando não houver perfil adequado, escolha stack somente depois de entender o problema e registrar a justificativa curta.
+9. Divida execução em blocos funcionais completos.
+10. Para cada bloco, defina critérios observáveis de conclusão.
+11. Use `core/TASK_ROUTER.md` para orientar onde cada fase deve acontecer.
+12. Registre decisões permanentes no repositório, não apenas no chat.
 
 ## Autonomia
 
-Não pergunte sobre detalhes técnicos rotineiros que possam ser decididos por boa prática e evidência. Recomende uma escolha e siga quando não houver necessidade real de preferência humana.
+Não pergunte sobre detalhes técnicos rotineiros que possam ser decididos por boa prática, evidência e um perfil já validado. Recomende uma escolha e siga quando não houver necessidade real de preferência humana.
 
 Pergunte apenas quando faltar regra de negócio, preferência subjetiva importante, orçamento, dado externo necessário ou autorização de risco.
 
 ## Saída esperada
 
-Objetivo, usuários/fluxos, escopo, arquitetura inicial, stack recomendada, riscos, blocos funcionais, critérios de sucesso e roteamento ChatGPT/Codex para a próxima fase.
+Objetivo, usuários/fluxos, escopo, perfil selecionado quando houver, arquitetura inicial, stack recomendada, módulos opcionais ativados, riscos, blocos funcionais, critérios de sucesso e roteamento ChatGPT/Codex para a próxima fase.

--- a/skills/factory-router/SKILL.md
+++ b/skills/factory-router/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: factory-router
-description: Use whenever a user asks to create, build, design, improve, modernize, maintain, debug, automate, integrate, migrate, extend, or continue a software project, app, system, website, API, browser extension, internal tool, automation, mobile app, desktop app, or GitHub project. Also use for broad outcome-only requests such as "quero criar um sistema", "quero um app", "melhore este projeto", or "automatize este processo". This is the universal entrypoint that classifies the work, chooses the minimum necessary App Factory process, routes between ChatGPT/Codex/other agents, and activates specialized Skills without requiring the user to mention App Factory explicitly.
+description: Use whenever a user asks to create, build, design, improve, modernize, maintain, debug, automate, integrate, migrate, extend, or continue a software project, app, system, website, API, browser extension, internal tool, automation, mobile app, desktop app, or GitHub project. Also use for broad outcome-only requests such as "quero criar um sistema", "quero um app", "melhore este projeto", or "automatize este processo". This is the universal entrypoint that classifies the work, selects a validated project profile when appropriate, chooses the minimum necessary App Factory process, routes between ChatGPT/Codex/other agents, and activates specialized Skills without requiring the user to mention App Factory explicitly.
 ---
 
 # Factory Router
@@ -24,20 +24,23 @@ Activate from software-development intent itself. The user may describe only an 
    - technical research/decision.
 4. If a project repository already exists, inspect its versioned state before planning from memory.
 5. Classify scale with `core/PROJECT_SCALE.md`.
-6. Apply `core/RISK_MODEL.md`.
-7. Choose the execution environment with `core/TASK_ROUTER.md`.
-8. Load only the specialized Skills needed for the current block.
-9. Prefer reuse of mature solutions when appropriate.
-10. Define and execute the largest safe complete functional slice possible in the current environment.
+6. Select a validated project profile from `profiles/` when the product clearly matches one; do not force a profile when none fits.
+7. Apply `core/RISK_MODEL.md`.
+8. Choose the execution environment with `core/TASK_ROUTER.md`.
+9. Load only the specialized Skills needed for the current block.
+10. Prefer reuse of mature solutions when appropriate.
+11. Define and execute the largest safe complete functional slice possible in the current environment.
 
 ## Common routing examples
 
 ### "Quero criar um sistema de patrimônio para a escola"
 
 - mode: new project;
+- likely profile: `web-admin`;
 - start with `app-planner`;
 - determine scale and product requirements;
-- make routine technical choices autonomously;
+- read `profiles/web-admin/PROFILE.md` before choosing routine stack details;
+- apply only modules the product actually needs;
 - use `ui-builder`, `architecture`, `database`, `security-review` and others only as needed;
 - move to Codex when implementation requires local repo, terminal, dependencies, tests or browser verification.
 
@@ -55,7 +58,7 @@ The user should not need to:
 
 - name the Factory;
 - choose a framework without reason;
-- know which Skill to invoke;
+- know which profile or Skill to invoke;
 - know whether ChatGPT or Codex is appropriate;
 - repeat context already stored in GitHub;
 - run commands an agent can safely run.

--- a/skills/ui-builder/SKILL.md
+++ b/skills/ui-builder/SKILL.md
@@ -1,17 +1,18 @@
 ---
 name: ui-builder
-description: Escolhe e aplica padrões de interface modernos para páginas, dashboards e sistemas, priorizando reutilização de componentes e consistência visual com shadcn, ReUI ou HeroUI conforme o tipo de aplicação.
+description: Escolhe e aplica padrões de interface modernos para páginas, dashboards e sistemas, priorizando reutilização, consistência visual e uso seletivo de shadcn, ReUI ou HeroUI conforme o tipo de aplicação.
 ---
 
 # UI Builder
 
 ## Decisão do design system
 
-1. Para sistemas administrativos, CRUDs, dashboards e ferramentas internas: avaliar primeiro **shadcn + ReUI**.
-2. Usar **shadcn** como base quando controle, composição e propriedade do código forem prioridades.
-3. Usar **ReUI** para acelerar padrões avançados e telas de sistema quando houver componente adequado.
+1. Para sistemas administrativos, CRUDs, dashboards e ferramentas internas: usar **shadcn/ui como base**.
+2. Usar **ReUI seletivamente** quando um componente administrativo avançado reduzir trabalho e justificar dependências/complexidade.
+3. Após instalar ReUI/registry, auditar arquivos e dependências adicionados e remover módulos não usados.
 4. Considerar **HeroUI** como alternativa principal em aplicações onde seu sistema visual ofereça vantagem clara.
 5. Não misturar HeroUI com shadcn/ReUI apenas para obter variedade visual.
+6. Quando o projeto seguir o perfil `web-admin`, consultar `profiles/web-admin/PROFILE.md`.
 
 ## Antes de construir
 

--- a/starters/web-admin/README.md
+++ b/starters/web-admin/README.md
@@ -1,51 +1,67 @@
-# web-admin — piloto V0.3
+# web-admin — perfil validado V0.4
 
-> Arquitetura candidata derivada da V0.2. Ainda não é starter estável.
+> Este diretório descreve como gerar o futuro starter `web-admin`. O código do piloto em `pilots/web-admin/` continua sendo evidência experimental e não deve ser copiado cegamente como template definitivo.
 
 ## Objetivo
 
-Validar a App Factory em um sistema administrativo realista sem carregar dependências que o produto não precisa.
+Criar sistemas administrativos reais com bootstrap enxuto, UI consistente, módulos opcionais e verificações reproduzíveis.
 
-## Base candidata
+## Base padrão do perfil
 
 - TypeScript;
-- Next.js como forte candidato para o piloto full-stack;
+- Next.js App Router;
+- React;
 - Tailwind CSS;
-- shadcn/ui;
-- ReUI para padrões avançados de admin;
-- Zod para contratos/validação;
-- Playwright para E2E;
-- Vitest para unit/integration quando adequado.
+- shadcn/ui como base do design system;
+- Zod para validação/contratos;
+- Vitest para unit/integration adequados;
+- Playwright para E2E crítico;
+- ESLint/configuração oficial do Next para lint específico.
 
-## Módulos opcionais
+Detalhes e limites: `profiles/web-admin/PROFILE.md`.
+
+## Módulos opcionais ativados por necessidade
 
 ### auth
 
-Candidato: Better Auth.
+Primeira opção do perfil quando login/identidade forem necessários: **Better Auth**.
 
-Ativar somente se o projeto exigir login/identidade.
+Não instalar autenticação em projetos que não precisam dela.
 
 ### database
 
-Candidato: Drizzle + banco escolhido conforme o ambiente.
+Primeira opção do perfil quando houver persistência própria: **Drizzle**.
 
-Ativar somente se houver persistência própria.
+O provider deve ser decidido conforme o ambiente. SQLite/better-sqlite3 fica como alternativa local/teste, não default de produção.
+
+### advanced-ui
+
+**ReUI seletivo**, por componente. Recomendado quando Data Grid, filtros complexos, calendário, Kanban ou outro padrão avançado reduzir trabalho de forma concreta.
+
+Após instalação:
+- revisar arquivos/dependências gerados;
+- remover módulos não usados;
+- executar lint/typecheck/testes.
+
+### formatting
+
+Biome pode ser usado como formatter complementar. Não substitui automaticamente o lint oficial do framework.
 
 ### forms
 
-Avaliar React Hook Form ou TanStack Form conforme complexidade e integração com componentes adotados. Não congelar antes do piloto.
+Começar simples. Avaliar React Hook Form/TanStack Form apenas quando a complexidade justificar.
 
 ### client-server-state
 
-TanStack Query entra quando cache/mutações client-side trouxerem benefício real. Não usar por padrão em toda página se Server Components/Server Actions ou fetch simples resolverem melhor.
+TanStack Query, Zustand ou equivalente entram apenas quando cache/sincronização/estado compartilhado trouxerem benefício real.
 
 ### observability
 
-Sentry/OpenTelemetry somente quando o ambiente/criticidade justificar.
+Sentry/OpenTelemetry somente conforme criticidade e operação real.
 
 ### monorepo
 
-Turborepo somente se houver múltiplos apps/pacotes com benefício concreto.
+Turborepo somente se existirem múltiplos apps/pacotes com benefício concreto.
 
 ## Estrutura candidata
 
@@ -59,32 +75,48 @@ src/
 │   └── <feature>/
 │       ├── components/
 │       ├── schemas/
-│       ├── api/
+│       ├── data/
 │       └── tests/
 ├── lib/
 ├── config/
 └── types/
 ```
 
-A organização feature-based foi reforçada por referências como Bulletproof React e pelo dashboard starter auditado. A Factory deve adaptar, não copiar cegamente.
+Simplificar para projetos menores quando necessário.
 
-## Fatia piloto
+## Primeira fatia funcional
 
-Construir um módulo completo de exemplo, como `items` ou `users`, contendo:
+O starter deve permitir construir um módulo completo como `items`, `users` ou equivalente, contendo quando aplicável:
 
 - listagem;
 - busca/filtros;
 - criação;
 - edição;
 - validação;
-- persistência quando o módulo de banco estiver ativo;
+- persistência;
 - loading/empty/error/success states;
 - responsividade;
 - testes unitários úteis;
 - fluxo E2E com Playwright.
 
-## Definition of Done do piloto
+## Gate obrigatório de reprodutibilidade
 
+O piloto V0.3 demonstrou que teste local não basta. O starter deve prever CI em checkout limpo com:
+
+1. package manager/lockfile consistente;
+2. instalação reproduzível (`npm ci` ou equivalente);
+3. setup/migrations/seed quando aplicável;
+4. format check;
+5. lint;
+6. typecheck sem depender de artefato gerado previamente;
+7. testes unit/integration;
+8. build;
+9. auditoria de dependências proporcional;
+10. Playwright desktop/mobile do fluxo crítico.
+
+## Definition of Done
+
+- instalação limpa passa;
 - lint/format validado;
 - typecheck;
 - testes;
@@ -93,18 +125,21 @@ Construir um módulo completo de exemplo, como `items` ou `users`, contendo:
 - fluxo crítico passa em Playwright;
 - desktop e mobile verificados;
 - nenhum segredo no repositório;
+- operações destrutivas relevantes têm proteção e teste;
 - diff revisado;
 - agentes conseguem retomar pelo GitHub sem contexto da conversa.
 
-## O que o piloto deve responder
+## O que já foi respondido pelo piloto V0.3
 
-1. A estrutura é simples para uma IA navegar?
-2. shadcn + ReUI convivem sem conflito relevante?
-3. Better Auth + Drizzle funciona de forma limpa quando ativado?
-4. Zod integra bem os contratos necessários?
-5. Playwright oferece feedback suficiente para o agente corrigir sozinho?
-6. Biome simplifica o tooling sem perder checks importantes?
-7. O Codex Plugin descobre e aplica as Skills corretamente?
-8. O processo exige pouca intervenção manual do usuário?
+1. **A estrutura é navegável por IA?** Sim, com documentação curta + código organizado + estado no GitHub.
+2. **shadcn + ReUI convivem?** Sim, mas ReUI funciona melhor como fonte seletiva de componentes avançados, não como segunda base obrigatória.
+3. **Better Auth + Drizzle funcionam juntos?** Sim no piloto; ambos foram promovidos como primeiras opções condicionais do perfil.
+4. **Zod funcionou bem?** Sim; promoção aprovada.
+5. **Playwright fornece feedback suficiente?** Sim; promoção aprovada como E2E crítico.
+6. **Biome substitui ESLint?** Não neste perfil; fica opcional/complementar.
+7. **Codex Plugin aplica Skills corretamente?** Sim, validado na fase anterior.
+8. **O processo reduziu intervenção manual?** Sim; o Codex executou scaffold, dependências, migrations, testes, browser e correções, e o ChatGPT fez a revisão/gates.
 
-Somente depois dessas respostas os candidatos viram defaults da V1.
+## Próximo passo técnico
+
+Transformar este perfil em um starter gerável limpo, separado do piloto, e validá-lo criando um segundo app do zero. Só então marcar o starter como V1 estável.

--- a/ui/UI_POLICY.md
+++ b/ui/UI_POLICY.md
@@ -8,11 +8,15 @@ Produzir interfaces atuais, consistentes e fáceis de manter sem transformar a a
 
 ### Admin, dashboard, CRUD, ferramentas internas
 
-Preferência inicial: **shadcn + ReUI**.
+Base preferencial: **shadcn/ui**.
+
+Usar **ReUI seletivamente** para componentes administrativos avançados quando o ganho justificar a complexidade, por exemplo Data Grid, filtros complexos, calendários, Kanban ou padrões equivalentes.
+
+O piloto V0.3 mostrou que ReUI agrega muito valor em componentes avançados, mas pode trazer arquivos/dependências opcionais que precisam de auditoria pós-instalação. Portanto, não tratar `shadcn + ReUI` como duas bases obrigatórias instaladas integralmente em todo admin.
 
 ### Aplicações altamente visuais
 
-Avaliar **HeroUI** como design system principal quando oferecer vantagem clara. Não adicioná-lo apenas para usar alguns componentes decorativos se o projeto já estiver coeso em shadcn/ReUI.
+Avaliar **HeroUI** como design system principal quando oferecer vantagem clara. Não adicioná-lo apenas para usar componentes decorativos se o projeto já estiver coeso em shadcn/ReUI.
 
 ## Regras
 
@@ -23,10 +27,15 @@ Avaliar **HeroUI** como design system principal quando oferecer vantagem clara. 
 5. Evitar dependências duplicadas para a mesma função.
 6. Preservar o design system vigente em manutenção, salvo redesign explícito.
 7. Criar tokens e convenções locais para não depender visualmente dos defaults da biblioteca.
+8. Após instalar código de registry, revisar arquivos/dependências adicionados e remover o que não for utilizado.
 
 ## Padrões mínimos de tela
 
 Quando aplicável, tratar loading, empty state, error state, success feedback, disabled, foco/teclado, responsividade, contraste/acessibilidade e densidade adequada ao contexto.
+
+## Perfil web-admin validado
+
+Consultar `profiles/web-admin/PROFILE.md` para defaults e módulos opcionais comprovados pelo piloto V0.3.
 
 ## Registry futuro
 


### PR DESCRIPTION
## Objetivo

Transformar apenas os aprendizados comprovados do piloto V0.3 em defaults condicionais reutilizáveis do perfil `web-admin`.

## Mudanças

- cria `profiles/` e o perfil validado `profiles/web-admin/PROFILE.md`;
- liga seleção de perfil ao `factory-router`, `app-planner` e `core/ENTRYPOINT.md`;
- promove shadcn como base visual do perfil;
- reclassifica ReUI como opcional/seletivo por componente;
- Better Auth e Drizzle viram primeiras opções condicionais quando auth/persistência forem necessárias;
- Zod, Vitest, Playwright e lint oficial do Next são promovidos no perfil;
- SQLite/better-sqlite3 permanece alternativa local/teste;
- Biome permanece complementar/opcional;
- documenta gates de lockfile, instalação limpa, CI e operações destrutivas aprendidos na Issue #8;
- atualiza README, starter, UI policy, changelog e PROJECT_STATE.

## Princípio

Perfil não é stack universal nem pacote obrigatório. O roteador deve entender o produto primeiro e ativar somente módulos necessários.

## Próximo gate

Depois do merge, criar uma Issue para Codex gerar um starter `web-admin` limpo e validar um segundo app do zero. O piloto V0.3 continua como evidência e não deve ser copiado cegamente.