### PR TITLE
docs: hand off V0.6 hardening

### DIFF
--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -4,21 +4,22 @@
 
 ## Objetivo atual
 
-Validar em revisão o starter `web-admin` limpo e o segundo aplicativo gerado do zero, provando que o conhecimento promovido na V0.4 é reutilizável.
+Endurecer o perfil `web-admin` antes da V1, provando recipes diretamente em geração limpa, adicionando um caminho PostgreSQL de produção e formalizando manutenção segura de Better Auth/schema.
 
 ## Estado
 
-- fase: `V0.5 — starter e segundo app implementados; aguardando revisão do draft PR`;
-- baseline oficial: `main` após merge do PR #9 (`2e2ca4e8fef963a1fe126b84e7ff55470742b66a`);
+- fase: `V0.6 — hardening pré-V1 do perfil web-admin`;
+- baseline oficial: `main` após merge do PR #11 (`7339a25f401813f6c05778e3f30228f518914a95`);
 - V0.1 bootstrap: concluída;
 - V0.2 pesquisa: concluída e integrada;
 - V0.2.1 entry router: concluído e integrado;
 - Issue #3 / Codex Plugin: concluída e revisada;
 - V0.3 piloto web-admin: concluído, revisado, CI reproduzível e integrado;
-- V0.4 perfil web-admin: concluído, CI aprovado e integrado;
-- Issues #4 e #8: concluídas;
-- Issue #10: implementação concluída localmente na branch `pilot/web-admin-starter-v0.5`;
-- CI: valida Core/Skills/plugin, piloto V0.3 e o novo starter/exemplo V0.5 em checkout limpo.
+- V0.4 perfil web-admin: concluído e integrado;
+- V0.5 starter + segundo app: concluída, revisada e integrada;
+- Issues #4, #8 e #10: concluídas;
+- Issue #12: aberta e liberada para Codex;
+- CI: valida Core/Skills/plugin, piloto V0.3, starter V0.5 e exemplo `asset-admin` em checkout limpo.
 
 ## Decisões vigentes
 
@@ -30,28 +31,27 @@ Validar em revisão o starter `web-admin` limpo e o segundo aplicativo gerado do
 - perfil não é dogma e módulos opcionais só entram quando necessários;
 - no perfil `web-admin`, shadcn é a base visual;
 - ReUI é opcional/seletivo por componente avançado;
-- HeroUI é perfil visual alternativo;
 - Better Auth é primeira opção condicional quando o projeto exige autenticação própria;
 - Drizzle é primeira opção condicional quando o projeto exige persistência própria;
-- provider de banco é escolhido pelo ambiente; SQLite/better-sqlite3 fica local/teste salvo requisito real;
+- SQLite/better-sqlite3 permanece provider local/teste, não default universal de produção;
+- V0.6 deve validar PostgreSQL como caminho de produção sem contaminar o starter base;
 - Zod, Vitest, Playwright e lint oficial do Next fazem parte da base validada do perfil;
-- Biome fica opcional/complementar;
-- Spec Kit continua proporcional à escala;
+- Biome permanece opcional/complementar;
 - starters permanecem componíveis, sem serviços opcionais impostos;
-- instalação limpa e CI reproduzível são gates, não apenas testes locais.
+- instalação limpa, recipes gerados e CI reproduzível são gates de qualidade;
+- migrations destrutivas não devem ser aplicadas automaticamente sem análise.
 
 ## Trabalho atual
 
-- bloco: Issue #10 — gerar starter limpo e validar segundo app do zero;
-- ambiente: Codex;
-- resultado: starter limpo, gerador, três recipes e `examples/asset-admin/` criados a partir do perfil V0.4;
-- decisão: Better Auth/Drizzle foram ativados no exemplo; ReUI foi dispensado por falta de complexidade que justificasse o grid;
-- evidência: `research/V0.5_WEB_ADMIN_STARTER_VALIDATION.md`, testes, workflow e screenshots V0.5;
-- regra: não fazer merge automático.
+- bloco: Issue #12 — hardening pré-V1 do perfil `web-admin`;
+- ambiente recomendado: Codex;
+- motivo: exige geração real de projetos, recipes, PostgreSQL, migrations, auth, CI, build e smoke de produção;
+- objetivo imediato: transformar `web-admin` em candidato `v1-rc` sem expandir ainda para outros perfis;
+- regra: abrir draft PR e não fazer merge automático.
 
 ## Próxima ação
 
-Revisar o draft PR da Issue #10 e os checks finais do gerador temporário e do exemplo antes de qualquer promoção para V1. Não fazer merge automático.
+Executar integralmente a Issue #12 no Codex. Ao concluir, devolver o draft PR e os checks para revisão do ChatGPT.
 
 ## Handoff
 
@@ -59,8 +59,8 @@ Outro agente deve começar por:
 
 1. `AGENTS.md`;
 2. este `PROJECT_STATE.md`;
-3. Issue #10;
+3. Issue #12;
 4. `profiles/web-admin/PROFILE.md`;
 5. `starters/web-admin/README.md`;
 6. `research/V0.5_WEB_ADMIN_STARTER_VALIDATION.md`;
-7. `examples/asset-admin/PROJECT_STATE.md` e `.app-factory.json`.
+7. `.github/workflows/validate-web-admin-starter.yml`.


### PR DESCRIPTION
Atualiza `PROJECT_STATE.md` após a integração da V0.5 e registra a Issue #12 como próximo bloco oficial. Mudança apenas de continuidade/estado; nenhum código funcional é alterado.