### PR TITLE
release: App Factory V1.0 stable

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "app-factory",
-  "version": "1.0.0-rc.1",
+  "version": "1.0.0",
   "description": "Portable AI software-development factory with automatic software-intent routing, planning, tool selection, architecture, UI, security and executable verification.",
   "author": {
     "name": "mcpmieda",

--- a/.github/workflows/validate-v1-release.yml
+++ b/.github/workflows/validate-v1-release.yml
@@ -1,4 +1,4 @@
-name: Validate V1 Release Candidate
+name: Validate V1 Release
 
 on:
   pull_request:
@@ -14,6 +14,8 @@ on:
       - "README.md"
       - "CHANGELOG.md"
       - "PROJECT_STATE.md"
+      - "profiles/web-admin/PROFILE.md"
+      - "starters/web-admin/template/**"
   workflow_dispatch:
 
 permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## 1.0.0 — 2026-08-21
+
+Primeira release estável da App Factory.
+
+### Aprovado para release
+
+- auditoria final end-to-end concluída sem blocker objetivo;
+- bootstrap isolado do plugin Codex com 11 Skills e integridade origem/cache;
+- roteamento por pedido comum sem palavra-chave especial;
+- sistema novo de empréstimos criado do zero, com persistência, regras de negócio e browser desktop/mobile;
+- Living UI e `prefers-reduced-motion` validados;
+- continuidade por segundo agente sem contexto e recuperação de regressão controlada comprovadas;
+- gates anteriores de web-admin, PostgreSQL/Auth, Living UI e quatro famílias universais permanecem verdes;
+- gerador e starter passam a derivar/registrar a baseline corrente da Factory, eliminando referência operacional antiga a V0.7;
+- perfil `web-admin` promovido de `v1-rc` para `v1`.
+
+### Evidência
+
+- `research/V1.0_FINAL_AUDIT.md`;
+- `audits/v1-final/equipment-loans/`;
+- `research/evidence/V1_CONTINUITY_HANDOFF.md`;
+- `research/evidence/V1_CONTROLLED_RECOVERY.md`;
+- `.github/workflows/validate-v1-release.yml`.
+
 ## 1.0.0-rc.1 — 2026-08-21
 
 Release candidate final da App Factory, sem tag ou publicação antecipada.
@@ -155,7 +179,7 @@ Promoção controlada dos aprendizados comprovados pelo piloto V0.3.
 ### Guardrails aprendidos
 
 - lockfile/package manager devem ser reproduzíveis entre desenvolvimento e CI;
-- CI deve usar instalação limpa (`npm ci` ou equivalente), não mascarar inconsistência com instalação permissiva;
+- CI deve usar instalação limpa (`npm ci` ou equivalente), não mascarar inconsistências com instalação permissiva;
 - typecheck/testes não podem depender silenciosamente de artefatos gerados previamente;
 - operações destrutivas relevantes devem ter proteção de domínio e teste E2E quando apropriado;
 - código vindo de registry deve ser auditado e módulos/dependências não usados removidos.

--- a/PROJECT_STATE.md
+++ b/PROJECT_STATE.md
@@ -4,27 +4,19 @@
 
 ## Objetivo atual
 
-Executar a **auditoria final V1.0 end-to-end em ambiente limpo**, provando bootstrap/plugin isolado, roteamento por pedido comum, criação real do zero, qualidade executável, continuidade por outro agente e recuperação após regressão controlada.
+Manter a **App Factory V1.0 estável** como baseline recuperável para criação e evolução de software por agentes, preservando validação executável, continuidade via GitHub e perfis condicionais.
 
 ## Estado
 
-- fase: `V1.0 release candidate — aguardando revisão final`;
-- baseline oficial: `main` após merge da V0.9 (`38421c037c04df1999701e56a7c8946e80bba486`);
-- V0.1 bootstrap: concluída e integrada;
-- V0.2 pesquisa: concluída e integrada;
-- V0.2.1 entry router: concluído e integrado;
-- V0.3 piloto web-admin: concluído e integrado;
-- V0.4 perfil web-admin: concluído e integrado;
-- V0.5 starter + segundo app: concluída e integrada;
-- V0.6 hardening PostgreSQL/Auth: concluído e integrado;
-- V0.7 Living UI / Semantic Motion: concluída e integrada;
-- V0.8 Living UI executável: concluída e integrada;
-- V0.9 validação universal: concluída, revisada e integrada;
-- Issue #22: concluída;
-- Issue #25: aberta e liberada para Codex;
-- perfil `web-admin`: `v1-rc`;
+- fase: `V1.0 — estável`;
+- versão: `1.0.0`;
+- baseline de release: `main` após a auditoria final V1.0;
+- V0.1 a V0.9: concluídas, revisadas e integradas;
+- Issue #25 / auditoria final V1.0: concluída e aprovada;
+- perfil `web-admin`: `v1`;
 - perfis `website`, `web-app`, `chrome-extension` e `automation`: `validated`;
-- CI: Core/Skills/plugin, web-admin starter/recipes, PostgreSQL/Auth real, asset-admin, Living UI e quatro pilotos universais.
+- plugin Codex: `1.0.0`, com bootstrap isolado e 11 Skills verificadas sem duplicação;
+- CI: Core/Skills/plugin, web-admin starter/recipes, PostgreSQL/Auth real, asset-admin, Living UI, quatro pilotos universais e gate V1 final.
 
 ## Decisões vigentes
 
@@ -38,24 +30,25 @@ Executar a **auditoria final V1.0 end-to-end em ambiente limpo**, provando boots
 - `prefers-reduced-motion` é obrigatório para movimento não essencial;
 - `web-admin` tem caminho validado Better Auth + Drizzle + PostgreSQL quando necessário;
 - website, web-app, Chrome extension e automation possuem contratos validados próprios;
-- instalação limpa, testes executáveis, CI reproduzível, recuperação e continuidade via GitHub são gates de release;
-- refinamentos não bloqueantes e novos perfis ficam para pós-V1.
+- instalação limpa, testes executáveis, CI reproduzível, recuperação e continuidade via GitHub são gates permanentes;
+- refinamentos não bloqueantes e novos perfis ficam para versões posteriores.
 
-## Trabalho atual
+## Evidência da V1.0
 
-- bloco: Issue #25 — auditoria final V1.0;
-- ambiente recomendado: Codex em configuração/diretórios isolados sempre que possível;
-- pedido final do teste é linguagem natural e não contém stack/framework;
-- projeto de auditoria deve nascer do zero e provar uma jornada real de empréstimo/devolução de equipamentos;
-- segundo agente sem contexto deve conseguir compreender, modificar e validar o projeto apenas pelo repositório;
-- uma regressão controlada deve ser detectada e recuperada antes do baseline final verde;
-- nenhuma tag/release V1.0 deve ser criada antes da revisão final do ChatGPT.
+- `research/V1.0_FINAL_AUDIT.md`;
+- `audits/v1-final/equipment-loans/`;
+- `research/evidence/V1_CONTINUITY_HANDOFF.md`;
+- `research/evidence/V1_CONTROLLED_RECOVERY.md`;
+- `.github/workflows/validate-v1-release.yml`;
+- `scripts/validate_v1_bootstrap.py` e `scripts/validate_v1_release.py`.
+
+A auditoria final comprovou bootstrap isolado do plugin, roteamento a partir de linguagem comum, criação de projeto novo, persistência e regra de negócio, browser desktop/mobile, reduced motion, continuidade por segundo agente sem contexto e detecção/recuperação de regressão controlada.
 
 ## Próxima ação
 
-Revisar o draft PR da Issue #25, seus checks, o relatório `research/V1.0_FINAL_AUDIT.md`, a evidência do segundo agente e o teste de recuperação. Não fazer merge, tag ou release antes dessa revisão.
+Usar V1.0 como baseline estável. Novos trabalhos devem nascer de necessidade real de produto ou manutenção; não criar nova fase apenas para refinamento cosmético ou expansão nominal de cobertura.
 
-Se todos os critérios objetivos passarem e o relatório declarar `APP FACTORY V1.0 READY FOR RELEASE`, a próxima ação será revisar, integrar e publicar/taguear a V1.0. Não criar fase intermediária apenas por refinamento.
+Escopos ainda não validados — como mobile nativo, desktop nativo, jogos e cloud complexa — devem receber piloto/evidência próprios antes de virarem perfis estáveis.
 
 ## Handoff
 
@@ -63,9 +56,9 @@ Outro agente deve começar por:
 
 1. `AGENTS.md`;
 2. este `PROJECT_STATE.md`;
-3. Issue #25;
-4. `core/ENTRYPOINT.md`;
-5. `skills/factory-router/SKILL.md`;
-6. `profiles/README.md`;
-7. somente depois, os Skills/perfis que o roteamento indicar;
-8. `research/V0.9_UNIVERSAL_VALIDATION.md` apenas como evidência anterior, não como instrução para copiar os pilotos.
+3. `core/ENTRYPOINT.md`;
+4. `skills/factory-router/SKILL.md`;
+5. `profiles/README.md`;
+6. o perfil indicado pelo produto;
+7. `ui/UI_POLICY.md` e `ui/MOTION_POLICY.md` quando houver interface;
+8. `research/V1.0_FINAL_AUDIT.md` quando precisar auditar a origem da release.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Depois, basta descrever o software em linguagem comum — por exemplo, `Quero cr
 13. `core/WORKFLOW.md` — ciclo de projeto novo e manutenção.
 14. `core/DEFINITION_OF_DONE.md` — como provar que terminou.
 15. `PORTABILITY.md` — continuidade entre agentes.
-16. `docs/CODEX_PLUGIN.md` — adaptador Codex validado em piloto.
+16. `docs/CODEX_PLUGIN.md` — adaptador Codex validado em piloto e auditoria final.
 
 ## Living UI / Semantic Motion
 
@@ -84,7 +84,7 @@ A política cobre seis funções: ambiente, interação, dados, estado, atençã
 
 ## Perfis
 
-### web-admin — candidato V1 (`v1-rc`)
+### web-admin — V1 estável (`v1`)
 
 Para sistemas administrativos, CRUDs, dashboards e ferramentas internas.
 
@@ -113,7 +113,7 @@ O perfil herda `Motion Profile: ambient`, reduzindo para comportamento `subtle` 
 
 O perfil completo está em `profiles/web-admin/PROFILE.md`.
 
-### Perfis universais V0.9 (`validated`)
+### Perfis universais (`validated`)
 
 `website`, `web-app`, `chrome-extension` e `automation` possuem um piloto completo e gates próprios. Os perfis registram contratos condicionais; Astro, Vite/React, Vite vanilla e Python foram adequados aos pilotos, mas não são stacks universais congeladas. Veja `research/V0.9_UNIVERSAL_VALIDATION.md`.
 
@@ -149,6 +149,8 @@ app-factory/
 │   ├── web-app-pilot/
 │   ├── chrome-extension-pilot/
 │   └── automation-pilot/
+├── audits/
+│   └── v1-final/
 ├── research/
 └── scripts/
 ```
@@ -179,6 +181,8 @@ app-factory/
 
 ## Estado
 
-Versão de trabalho: `1.0.0-rc.1` — **V1.0 release candidate, aguardando revisão final**.
+Versão estável: **`1.0.0` — App Factory V1.0**.
 
-O perfil `web-admin` está em `v1-rc`; os quatro perfis universais estão `validated`. A auditoria final exercita bootstrap isolado, criação real de um novo `web-admin`, continuidade entre agentes e recuperação controlada. Nenhuma tag ou release V1.0 foi publicada.
+A auditoria final comprovou bootstrap isolado do plugin, roteamento por pedido comum, criação real de um novo sistema do zero, persistência e regras de negócio, desktop/mobile/reduced-motion, continuidade por segundo agente sem contexto e recuperação após regressão controlada. O perfil `web-admin` está em `v1`; os perfis `website`, `web-app`, `chrome-extension` e `automation` permanecem `validated` até acumularem mais evidência.
+
+Escopos ainda não validados — como mobile nativo, desktop nativo, jogos e infraestrutura cloud complexa — ficam para versões posteriores e não são promessa da V1.0.

--- a/docs/CODEX_PLUGIN.md
+++ b/docs/CODEX_PLUGIN.md
@@ -28,7 +28,7 @@ O manifest aponta `skills` para `./skills/`, que já é a fonte portátil usada 
 
 ## Estado
 
-`1.0.0-rc.1` — **release candidate aguardando revisão final**.
+`1.0.0` — **V1.0 estável**.
 
 O Codex CLI oficial `0.149.0` reconhece o marketplace local, instala a App Factory e descobre as 11 Skills, incluindo `factory-router`. A auditoria V1 compara SHA-256 de todas as Skills entre o checkout limpo e o cache instalado e rejeita omissão, duplicação, divergência ou pacote pesado.
 
@@ -54,17 +54,18 @@ python scripts/validate_factory.py
 python scripts/validate_skills.py
 python scripts/validate_plugin.py
 python scripts/validate_v1_bootstrap.py
+python scripts/validate_v1_release.py
 ```
 
 No piloto também foi usado o validador oficial do `plugin-creator`.
 
 As evidências completas estão em:
 
-`research/V0.2_CODEX_PLUGIN_PILOT.md` (piloto histórico) e `research/V1.0_FINAL_AUDIT.md` (gate atual).
+`research/V0.2_CODEX_PLUGIN_PILOT.md` (piloto histórico) e `research/V1.0_FINAL_AUDIT.md` (auditoria final).
 
 ## Resultado arquitetural
 
-O piloto confirmou o desenho:
+O piloto e a auditoria final confirmaram o desenho:
 
 ```text
 APP FACTORY CORE
@@ -84,7 +85,7 @@ Nenhum arquivo do Core ou Skill é mantido como segunda fonte. O cache de instal
 
 ## MCP e hooks
 
-Não adicionar MCP ou hooks por padrão nesta fase.
+Não adicionar MCP ou hooks por padrão.
 
 Eles só entram quando houver caso concreto em que:
 

--- a/profiles/web-admin/PROFILE.md
+++ b/profiles/web-admin/PROFILE.md
@@ -1,6 +1,6 @@
 # Web Admin Profile
 
-Status: `v1-rc`
+Status: `v1`
 
 Este perfil consolida somente decisões comprovadas pelo piloto V0.3 e pelos hardenings posteriores. Ele não é uma stack universal para todo software.
 
@@ -167,4 +167,4 @@ Mudanças de recipe também exigem geração limpa direta de cada caminho de pro
 
 ## Evidência de origem
 
-Perfil derivado de `research/V0.3_WEB_ADMIN_PILOT.md`, da validação reutilizável em `research/V0.5_WEB_ADMIN_STARTER_VALIDATION.md`, do hardening PostgreSQL/recipes em `research/V0.6_WEB_ADMIN_HARDENING.md` e da política universal de motion em `ui/MOTION_POLICY.md`.
+Perfil derivado de `research/V0.3_WEB_ADMIN_PILOT.md`, da validação reutilizável em `research/V0.5_WEB_ADMIN_STARTER_VALIDATION.md`, do hardening PostgreSQL/recipes em `research/V0.6_WEB_ADMIN_HARDENING.md`, da política universal de motion em `ui/MOTION_POLICY.md` e da auditoria final `research/V1.0_FINAL_AUDIT.md`.

--- a/scripts/validate_v1_release.py
+++ b/scripts/validate_v1_release.py
@@ -84,7 +84,8 @@ def validate_version_coherence() -> None:
         template / "src/config/project.ts": f'factoryBaseline: "{expected_baseline}"',
         template / "src/config/project.test.ts": f'factoryBaseline: "{expected_baseline}"',
         ROOT / "README.md": version,
-        ROOT / "PROJECT_STATE.md": "V1.0 release candidate",
+        ROOT / "PROJECT_STATE.md": "V1.0 — estável",
+        ROOT / "profiles/web-admin/PROFILE.md": "Status: `v1`",
     }
     for path, marker in required_markers.items():
         if marker not in path.read_text(encoding="utf-8"):

--- a/starters/web-admin/template/.factory-template.json
+++ b/starters/web-admin/template/.factory-template.json
@@ -1,7 +1,7 @@
 {
   "profile": "web-admin",
   "motionProfile": "ambient",
-  "factoryBaseline": "v1.0.0-rc.1",
+  "factoryBaseline": "v1.0.0",
   "optionalModules": [
     "auth-better-auth",
     "database-drizzle",

--- a/starters/web-admin/template/PROJECT_STATE.md
+++ b/starters/web-admin/template/PROJECT_STATE.md
@@ -8,7 +8,7 @@ Implement the first complete functional slice of **Web Admin Starter**.
 
 - phase: bootstrap;
 - App Factory profile: `web-admin`;
-- Factory baseline: `v1.0.0-rc.1`;
+- Factory baseline: `v1.0.0`;
 - Motion Profile: `ambient` contextual;
 - authentication: not activated;
 - persistence: not activated;

--- a/starters/web-admin/template/src/config/project.test.ts
+++ b/starters/web-admin/template/src/config/project.test.ts
@@ -6,7 +6,7 @@ describe("projectConfig", () => {
   it("records the reusable Factory profile and baseline", () => {
     expect(projectConfig).toMatchObject({
       profile: "web-admin",
-      factoryBaseline: "v1.0.0-rc.1",
+      factoryBaseline: "v1.0.0",
     });
     expect(projectConfig.name.length).toBeGreaterThan(1);
   });

--- a/starters/web-admin/template/src/config/project.ts
+++ b/starters/web-admin/template/src/config/project.ts
@@ -12,5 +12,5 @@ export const projectConfig = projectConfigSchema.parse({
   description:
     "Uma base administrativa enxuta para implementar a primeira fatia funcional.",
   profile: "web-admin",
-  factoryBaseline: "v1.0.0-rc.1",
+  factoryBaseline: "v1.0.0",
 });


### PR DESCRIPTION
## App Factory V1.0

Finaliza a candidata aprovada como release estável `1.0.0`.

- plugin passa de `1.0.0-rc.1` para `1.0.0`;
- gerador deriva a baseline da versão do plugin e novos projetos passam a registrar `v1.0.0`;
- starter e testes ficam coerentes com a release;
- perfil `web-admin` passa de `v1-rc` para `v1`;
- README, Codex plugin docs, CHANGELOG e PROJECT_STATE passam ao estado estável;
- gate V1 fiscaliza a coerência entre plugin, starter, docs e perfil.

A auditoria histórica permanece em `research/V1.0_FINAL_AUDIT.md`. Nenhuma tag/release GitHub é criada por este PR.