### PR TITLE
Policy: simple inspection URLs and project placement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,11 +19,12 @@ Leia `core/ENTRYPOINT.md` para o contrato de ativação automática.
 7. Use `core/EXECUTION_FABRIC.md` + `execution-router` para traduzir a ação em capacidades e eliminar backends incapazes/indisponíveis.
 8. Quando houver histórico local suficiente, aplique `core/LEARNING_ENGINE.md`/`learning-engine` somente entre candidatos já elegíveis; sem evidência suficiente, preserve o baseline.
 9. Aplique `core/RISK_MODEL.md`; risco e Definition of Done vencem qualquer preferência aprendida.
-10. Consulte `core/WORKFLOW.md` para projeto novo ou manutenção.
-11. Carregue somente as Skills relevantes.
-12. Consulte templates, políticas e referências apenas quando necessários.
-13. Antes de criar algo do zero, verifique se existe solução consolidada, componente, biblioteca, template ou registry adequado.
-14. Não misture tecnologias, bibliotecas ou design systems sem ganho claro.
+10. Para software real novo, use `projects/<slug>/` como destino padrão e siga `core/INSPECTION_ENVIRONMENT.md` para URL canônica, preview e hospedagem.
+11. Consulte `core/WORKFLOW.md` para projeto novo ou manutenção.
+12. Carregue somente as Skills relevantes.
+13. Consulte templates, políticas e referências apenas quando necessários.
+14. Antes de criar algo do zero, verifique se existe solução consolidada, componente, biblioteca, template ou registry adequado.
+15. Não misture tecnologias, bibliotecas ou design systems sem ganho claro.
 
 ## Regra de serviço ao usuário
 
@@ -39,6 +40,7 @@ Prefira:
 - decisões técnicas rotineiras autônomas;
 - `current_agent` + GitHub/CI antes de handoff;
 - aprendizado local conservador quando houver evidência real suficiente;
+- endereço de inspeção simples e estável sob `escolaieda.com/<slug>` quando a infraestrutura estiver configurada;
 - explicações simples para decisões relevantes.
 
 Consulte o usuário quando a decisão envolver objetivo de produto, preferência subjetiva, gasto, risco destrutivo, credencial/dado indisponível ou decisão legal/organizacional.

--- a/core/INSPECTION_ENVIRONMENT.md
+++ b/core/INSPECTION_ENVIRONMENT.md
@@ -1,0 +1,92 @@
+# Inspection Environment
+
+## Objetivo
+
+Dar ao usuário um endereço simples e estável para abrir qualquer sistema criado pela App Factory, escondendo detalhes de GitHub Pages, Vercel, previews e infraestrutura.
+
+## Padrão de projeto
+
+Software real novo criado pela Factory deve ir, por padrão, para:
+
+```text
+projects/<slug-do-projeto>/
+```
+
+Exemplo:
+
+```text
+projects/bancodenotas/
+```
+
+As demais pastas têm papéis diferentes:
+
+- `examples/`: pilotos e exemplos da própria Factory;
+- `audits/`: projetos/evidências de auditoria;
+- `starters/`: moldes reutilizáveis;
+- `projects/`: sistemas reais do usuário.
+
+## URL canônica
+
+O endereço apresentado ao usuário deve preferir:
+
+```text
+https://escolaieda.com/<slug>
+```
+
+Exemplos:
+
+```text
+https://escolaieda.com/bancodenotas
+https://escolaieda.com/patrimonio
+https://escolaieda.com/emprestimos
+```
+
+O slug público deve ser curto, minúsculo, sem acentos, espaços ou pontuação quando isso não causar ambiguidade. Exemplo: `Banco de Notas` → `bancodenotas`.
+
+## Hospedagem por trás do link
+
+A URL pública não deve obrigar uma única tecnologia de hospedagem.
+
+### Conteúdo estático
+
+Pode ser servido diretamente pelo site escolar, mantendo o caminho canônico sob `escolaieda.com`.
+
+### Aplicação com runtime/backend
+
+Pode usar Vercel ou outro backend adequado. O domínio principal deve fazer rewrite/proxy de `/<slug>` para o backend, preservando a URL visível no navegador.
+
+Exemplo conceitual:
+
+```text
+escolaieda.com/bancodenotas
+        ↓ rewrite/proxy
+bancodenotas.vercel.app
+```
+
+O usuário continua vendo `escolaieda.com/bancodenotas`.
+
+## Preview
+
+Branches/PRs podem usar URLs temporárias de preview para testes técnicos. Essas URLs não são o endereço principal entregue ao usuário.
+
+Fluxo desejado:
+
+```text
+alteração
+→ preview temporário
+→ testes/CI
+→ aprovação/merge
+→ endereço canônico existente atualizado
+```
+
+## Infraestrutura atual
+
+O `escolaieda.com` atual usa conteúdo estático no repositório `mcpmieda/escolaieda` com `CNAME`. Isso permite caminhos estáticos diretamente, mas não fornece sozinho reverse proxy para aplicações hospedadas em outro backend.
+
+Para preservar `escolaieda.com/<slug>` também em aplicações complexas, a implantação futura deve adicionar uma camada de roteamento que suporte rewrites/proxy. Vercel é o caminho preferido por simplicidade e por já suportar rewrites para destinos externos mantendo a URL original.
+
+Essa mudança de domínio/roteamento é uma implantação controlada e não deve ser feita implicitamente durante a criação de um projeto comum.
+
+## Regra de experiência
+
+O usuário não deve precisar escolher hospedagem, configurar link de preview ou memorizar URL técnica. A Factory decide o backend, automatiza a publicação quando a infraestrutura estiver disponível e entrega principalmente o endereço canônico simples.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -22,5 +22,10 @@
 - **D-020:** Learning Engine é local-only e privacy-safe por padrão; somente metadados técnicos allowlisted podem ser persistidos e nenhuma telemetria externa é enviada.
 - **D-021:** aprendizado é subordinado a capacidade, disponibilidade, fallback da tarefa, segurança/risco e Definition of Done; amostra pequena não altera o baseline e `local_full` não é promovido sobre backend leve capaz apenas por score.
 - **D-022:** duração usada pelo aprendizado mede execuções bem-sucedidas; falhar rápido nunca deve melhorar a preferência de executor.
+- **D-023:** software real novo criado pela Factory deve usar, por padrão, `projects/<slug-do-projeto>/`; `examples/`, `audits/` e `starters/` permanecem reservados a evidência, auditoria e moldes da própria Factory.
+- **D-024:** o endereço canônico de inspeção/uso deve ser simples e baseado em caminho sob `escolaieda.com`, por exemplo `https://escolaieda.com/bancodenotas`; o slug público preferido é compacto, em minúsculas, sem acentos, espaços ou pontuação quando isso não gerar ambiguidade.
+- **D-025:** hospedagem é detalhe interno: conteúdo estático pode ser servido diretamente pelo site escolar; aplicações com backend/runtime podem usar Vercel ou outro backend adequado, mas devem permanecer acessíveis pelo mesmo padrão `escolaieda.com/<slug>` através de rewrite/proxy quando a infraestrutura permitir.
+- **D-026:** URLs temporárias de preview/deploy são técnicas e descartáveis; a Factory deve apresentar ao usuário principalmente o endereço canônico simples e manter o mesmo link após atualizações aprovadas.
+- **D-027:** alterações de DNS, domínio ou roteamento global do `escolaieda.com` são infraestrutura de maior impacto e exigem implantação controlada; até essa camada estar configurada, a Factory deve registrar a URL canônica desejada sem fingir que o roteamento já existe.
 
 Quando uma decisão for substituída, registrar a nova decisão e marcar a anterior como superada; não apagar silenciosamente o histórico.


### PR DESCRIPTION
Records the approved inspection/deployment convention without changing DNS or production infrastructure.

- real user software defaults to `projects/<slug>/`;
- canonical public URL is `https://escolaieda.com/<compact-slug>` (for example `/bancodenotas`);
- static content may be served directly by the school site;
- complex apps may run on Vercel/another backend behind rewrite/proxy while preserving the simple visible URL;
- preview URLs remain technical/temporary;
- current `escolaieda.com` GitHub Pages setup is documented as insufficient by itself for cross-origin reverse proxy, so DNS/routing migration remains a controlled future infrastructure step.