### PR TITLE
Ambient constellation — calibrar microescala pela referência HeroUI Pro

### DIFF
--- a/docs/AMBIENT_CONSTELLATION_CALIBRATION_2026-08-25.md
+++ b/docs/AMBIENT_CONSTELLATION_CALIBRATION_2026-08-25.md
@@ -1,0 +1,43 @@
+# Calibração visual — Ambient Constellation — 2026-08-25
+
+## Motivo
+
+A implementação inicial do Centro de Administração mostrou partículas excessivamente grandes em relação à página. O problema não era falta de densidade, mas escala: um SVG `0 0 100 100` preenchia superfícies grandes usando círculos com raio próximo de `1`, fazendo os pontos crescerem junto com a viewport.
+
+## Referência oficial inspecionada
+
+Foi usada a implementação pública atual do banner/modal HeroUI Pro em `heroui-inc/heroui`:
+
+- card: 288px de largura;
+- área visual superior: 180px de altura;
+- `FloatingStars`: aproximadamente 760.706 × 637.702px;
+- wrapper visual: `scale-50`;
+- campo efetivo antes do recorte: aproximadamente 380 × 319px;
+- overscan aproximado: 1.32× em largura e 1.77× em altura;
+- duas camadas de estrelas;
+- drift de 12s e 15s em direções opostas;
+- deslocamento-fonte de 40px, percebido próximo de 20px após a escala;
+- partículas majoritariamente muito pequenas, com opacidades baixas (`0.11`, `0.3` e variações) dentro de grupo parcialmente transparente.
+
+## Regra consolidada
+
+A App Factory passa a tratar `strong` como intensidade por composição, densidade, profundidade e glow. A escala das partículas fica limitada em screen-space e não deve crescer proporcionalmente à viewport.
+
+Baseline recomendado:
+
+- partículas comuns: 0.6–1.2 CSS px;
+- secundárias: 1.2–1.5 CSS px;
+- glints raros: até ~1.8 CSS px;
+- desktop: maior partícula típica ≤ 2 CSS px;
+- mobile: maior partícula típica ≤ 1.5 CSS px;
+- overscan do campo: ~1.25–1.45× largura e ~1.55–1.90× altura;
+- drift visual: ~14–24px desktop e ~8–16px mobile;
+- dois ciclos assíncronos, com 12s/15s como baseline HeroUI.
+
+## Anti-padrão proibido
+
+Não usar `viewBox="0 0 100 100"` em uma superfície grande com `r≈1` para representar estrelas. Isso converte microestrelas em círculos grandes conforme a superfície cresce.
+
+## Resultado esperado
+
+A constelação deve ser percebida como poeira luminosa e profundidade ambiental. Nenhum ponto individual deve competir visualmente com texto, botões, cards ou navegação.

--- a/skills/ui-builder/SKILL.md
+++ b/skills/ui-builder/SKILL.md
@@ -49,6 +49,7 @@ Se o usuário disser `ambient constellation`, `ambient constellarion`, `ambiente
 Motion Profile: ambient
 Ambient Surface Profile: ambient-constellation
 Constellation Intensity: strong
+Particle scale: micro, screen-space bounded
 ```
 
 Aplicar fortemente às superfícies existentes listadas no perfil: shell/background, page header, hero/welcome, dashboard overview, login/auth, empty/waiting/onboarding, painéis de destaque, modal/drawer importante, AI/assistant e cards/CTA especiais.
@@ -71,13 +72,17 @@ Mesmo em tela densa, não apagar toda a assinatura. Colocar tabelas/forms/grids 
 - pelo menos duas profundidades/camadas em superfícies fortes;
 - períodos lentos diferentes e não sincronizados;
 - glow grande e preferencialmente estático;
-- partículas com opacidades/tamanhos variados;
-- presença por composição e área, não por velocidade;
+- **micro-partículas**, normalmente em torno de `0.6–1.5 CSS px`, com raros glints maiores;
+- presença por composição, densidade e área, não por diâmetro ou velocidade;
+- campo maior que a área visível e recortado, aproximadamente `1.25–1.45×` em largura e `1.55–1.90×` em altura como referência;
+- baseline HeroUI Pro: drift visual aproximadamente `20px`, ciclos de `12s` e `15s` em direções opostas;
 - nenhuma partícula sobre conteúdo interativo ou texto denso;
 - `pointer-events: none`, decoração fora da árvore acessível;
 - CSS `transform`/`opacity` para loops simples;
 - evitar cursor/scroll parallax por padrão;
 - zero strobe/blinking.
+
+**Nunca** usar um campo SVG `0 0 100 100` em tela cheia com círculos de raio próximo a `1`, nem qualquer modelagem que faça os pontos crescerem proporcionalmente à viewport. Se os pontos parecem bolhas/círculos voadores em zoom 100%, a implementação falhou mesmo que a intensidade esteja configurada como `strong`.
 
 ## Professional UI Profile
 
@@ -142,7 +147,7 @@ Pesquisar primeiro no design system/registry atual. Não criar componente própr
 
 Referências comerciais como HeroUI Pro podem inspirar padrões públicos de composição e linguagem visual. Não copiar código, templates, assets ou screenshots proprietários para a Factory sem licença específica.
 
-A referência de `ambient-constellation` vem do site/repositório OSS HeroUI v3, licenciado sob Apache-2.0. A Factory prefere primitive própria; se código OSS for copiado diretamente para um projeto, cumprir licença/NOTICE.
+A referência de `ambient-constellation` vem do site/repositório OSS HeroUI v3. A Factory prefere primitive própria; se código OSS for copiado diretamente para um projeto, cumprir a licença aplicável e NOTICE quando exigido.
 
 ## Motion Profile
 
@@ -180,7 +185,7 @@ Evitar aparência genérica de app gerado por IA. Usar hierarquia clara, espaça
 
 Uma interface viva não significa movimento em tudo. Conteúdo principal deve permanecer legível e estável.
 
-Em HeroUI, a constelação deve ser uma assinatura visual recorrente e reconhecível; áreas densas ficam limpas por composição, não por abandono completo da assinatura.
+Em HeroUI, a constelação deve ser uma assinatura visual recorrente e reconhecível; áreas densas ficam limpas por composição, não por abandono completo da assinatura. A referência de escala é de **poeira luminosa**, não de círculos decorativos.
 
 ## Regra de sistema
 
@@ -196,6 +201,8 @@ Também verificar quando aplicável:
 - loading/empty/error e ação destrutiva;
 - coerência com Motion Profile;
 - `ambient-constellation` perceptível onde exigido;
+- **maior partícula típica ≤ 2 CSS px em desktop e ≤ 1.5 CSS px em mobile**, salvo exceção explícita;
+- nenhum ponto recorrente parece bolha/círculo voador;
 - partículas não bloqueiam interação;
 - dense content continua limpo;
 - `prefers-reduced-motion` gera fallback estático;

--- a/ui/AMBIENT_CONSTELLATION_PROFILE.md
+++ b/ui/AMBIENT_CONSTELLATION_PROFILE.md
@@ -2,9 +2,11 @@
 
 ## Objetivo
 
-`ambient-constellation` é a assinatura ambiental reutilizável da App Factory para interfaces vivas com linguagem de constelação: gradientes frios/brand-aware, glows difusos e camadas de partículas/estrelas que derivam lentamente em velocidades diferentes.
+`ambient-constellation` é a assinatura ambiental reutilizável da App Factory para interfaces vivas com linguagem de constelação: gradientes frios/brand-aware, glows difusos e camadas de micro-partículas/estrelas que derivam lentamente em velocidades diferentes.
 
 O efeito deve ser **claramente perceptível pelo usuário**, mas continuar atrás da tarefa. Ele cria profundidade e identidade sem competir com leitura, foco, navegação ou dados.
+
+> Regra central: presença forte vem de **área, densidade, profundidade e glow**, não de partículas grandes. Em escala normal de tela, a constelação deve parecer poeira luminosa/microestrelas, nunca círculos voadores.
 
 ## Ativação
 
@@ -48,22 +50,49 @@ A referência pública principal é o banner/modal HeroUI Pro no repositório OS
 
 - superfície clara azul/lilás;
 - blob/glow ciano→violeta fortemente desfocado;
-- partículas brancas com diferentes tamanhos e opacidades;
+- partículas brancas muito pequenas com diferentes opacidades;
 - duas camadas de estrelas em drift diagonal oposto;
 - ciclos diferentes, evitando sincronização visual;
 - conteúdo em camada superior, com partículas sem interação.
 
-Parâmetros observados na implementação oficial em 2026-08-24, usados como **baseline de comportamento**, não como obrigação de copiar valores literalmente:
+### Calibração proporcional da referência oficial — 2026-08-25
 
-- base aproximada: `#E9E9FF → #CCE5F1`;
-- glow aproximado: `#5DD0E7 → #7300FF`;
-- drift A: ~12 s, deslocamento diagonal de ~40 px e retorno;
-- drift B: ~15 s, direção oposta e retorno;
-- easing: `ease-in-out`;
-- partículas com opacidades variadas e baixa dominância;
-- overflow recortando um campo de estrelas maior que a superfície visível.
+A inspeção da implementação oficial atual mostrou um detalhe que deve ser preservado na Factory:
 
-O repositório HeroUI v3 está sob Apache-2.0. Se um projeto copiar código OSS diretamente, cumprir os requisitos de licença/NOTICE. A Factory prefere uma primitive própria baseada nos padrões gerais, para facilitar branding e portabilidade.
+- card/modal: `288px` de largura;
+- faixa visual superior: `180px` de altura;
+- primitive `FloatingStars`: aproximadamente `760.706 × 637.702px`;
+- o campo inteiro é centralizado e renderizado dentro de `scale-50` antes do recorte;
+- portanto, antes do clipping, o campo efetivo fica em aproximadamente `380 × 319px`, ou cerca de **1,32× a largura e 1,77× a altura** da área visível;
+- as estrelas usam um SVG `709.134 × 573.351` com glints muito pequenos; muitas partículas recebem opacidade `0.11` ou `0.3` dentro de um grupo com opacidade `0.7`;
+- drift A: `12s`, ida de aproximadamente `40px` em X/Y e retorno;
+- drift B: `15s`, direção oposta e retorno;
+- como o conjunto é exibido em `scale-50`, a amplitude visual observada fica aproximadamente na ordem de **20px**, não 40px;
+- o efeito final é de micro-pontos/poeira luminosa, sem discos grandes perceptíveis.
+
+Essas proporções são **baseline de comportamento**, não uma obrigação de copiar o SVG oficial.
+
+### Regra de escala das partículas
+
+Para superfícies web comuns:
+
+- maioria das partículas: aproximadamente `0.6–1.2 CSS px` de diâmetro percebido;
+- partículas secundárias: aproximadamente `1.2–1.5 CSS px`;
+- glints raros podem chegar a aproximadamente `1.8 CSS px`, mas não devem formar discos dominantes;
+- mobile: preferir `0.5–1.3 CSS px`;
+- evitar qualquer partícula recorrente acima de `2 CSS px` salvo efeito específico e deliberado;
+- variar principalmente **opacidade**, não tamanho.
+
+Nunca dimensionar o raio da partícula como porcentagem direta da viewport. Em especial, evitar SVG de `viewBox="0 0 100 100"` ocupando a tela inteira com círculos de `r≈1`: em uma viewport grande isso pode virar discos de dezenas de pixels.
+
+### Regra de overscan/crop
+
+O campo de estrelas deve ser maior do que a superfície e depois recortado. Como baseline:
+
+- largura do campo: aproximadamente `1.25–1.45×` a área visível;
+- altura do campo: aproximadamente `1.55–1.90×` a área visível;
+- centralizar/offsetar o campo para que partículas entrem e saiam naturalmente;
+- nunca ampliar as próprias partículas para conseguir presença visual.
 
 ## Composição obrigatória
 
@@ -71,32 +100,34 @@ Uma superfície `ambient-constellation` forte deve possuir, quando a plataforma 
 
 1. **base tonal** — gradiente ou superfície temática coerente com a marca;
 2. **glow/blob grande** — difuso, estático ou quase estático, sem borda dura;
-3. **camada de partículas A** — drift lento;
-4. **camada de partículas B** — velocidade diferente e direção contrária/defasada;
+3. **camada de micro-partículas A** — drift lento;
+4. **camada de micro-partículas B** — velocidade diferente e direção contrária/defasada;
 5. **conteúdo foreground** — legível, estável e separado do efeito;
-6. **overflow/mask** — partículas entram/saem naturalmente da área visível;
+6. **overscan + overflow/mask** — campo maior que a área e recortado;
 7. **fallback estático** — para reduced motion/performance.
 
-Não depender de estrelas perfeitas. Pontos, pequenos glints, microcruzes e partículas suaves podem coexistir; evitar confete, neve ou aparência de screensaver.
+Não depender de estrelas perfeitas. Pontos, pequenos glints e microcruzes podem coexistir; evitar confete, neve, bolhas ou aparência de screensaver.
 
 ## Intensidade `strong`
 
-`strong` significa presença visual inequívoca, não movimento rápido.
+`strong` significa presença visual inequívoca, não movimento rápido nem partículas grandes.
 
 A percepção deve vir de:
 
 - contraste tonal suficiente entre base e glow;
+- **densidade de micro-pontos**, não diâmetro de pontos;
 - campo de partículas visível à primeira observação;
 - pelo menos duas profundidades/camadas;
 - composição ocupando área visual relevante;
 - períodos longos e não sincronizados;
-- pequenas diferenças de tamanho/opacidade entre partículas;
+- pequenas diferenças de opacidade/tamanho entre partículas;
 - reforço em superfícies-chave do produto.
 
 Evitar tornar `strong` por:
 
 - acelerar partículas;
 - aumentar drasticamente amplitude;
+- aumentar diâmetro até os pontos parecerem círculos;
 - piscar/twinkle rápido;
 - colocar estrelas sobre texto e controles;
 - usar saturação extrema em toda a viewport.
@@ -107,7 +138,7 @@ Quando o perfil estiver ativo, aplicar **fortemente** às superfícies que exist
 
 | Superfície | Regra |
 | --- | --- |
-| App shell/background | camada persistente de baixa/média densidade, sem interferir no conteúdo |
+| App shell/background | camada persistente de baixa/média densidade, micro-partículas discretas, sem interferir no conteúdo |
 | Cabeçalho/page header | constelação média/forte, preferencialmente uma das assinaturas principais |
 | Boas-vindas/hero | forte |
 | Dashboard overview/summary | forte na área de síntese; não atrás de tabelas densas |
@@ -128,12 +159,14 @@ Em um sistema HeroUI, não desligar a constelação de uma tela inteira apenas p
 
 ### Multi-layer asynchronous drift
 
-Default recomendado:
+Default recomendado, calibrado para a referência HeroUI:
 
 - 2 camadas animadas; 3 apenas quando houver espaço/performance;
-- ciclos diferentes, por exemplo `12–18s` e `15–24s`;
-- amplitude desktop típica `24–48px`;
-- amplitude mobile típica `12–28px`;
+- baseline preferencial: aproximadamente `12s` e `15s`;
+- faixa aceitável: `12–18s` e `15–24s`;
+- amplitude visual desktop típica: `14–24px`;
+- amplitude visual mobile típica: `8–16px`;
+- usar amplitudes maiores somente em superfícies muito grandes e sempre preservando movimento lento;
 - trajetórias diagonais ou curvas simples;
 - direções opostas ou fases diferentes;
 - `ease-in-out` ou easing suave equivalente;
@@ -161,15 +194,26 @@ Não usar por padrão. Só adicionar em perfil `expressive` ou experiência espe
 
 Preferir:
 
-1. SVG ou pseudo-elementos para campo visual;
-2. animação CSS de grupos por `transform` e, quando necessário, `opacity`;
-3. blur/glow **estático**; não animar blur continuamente;
-4. `pointer-events: none` e `aria-hidden="true"` para decoração;
-5. conteúdo em stacking context superior;
-6. `overflow: hidden|clip` na superfície;
-7. primitive reutilizável em vez de dezenas de partículas DOM independentes.
+1. SVG agregado ou camada única de micro-pontos posicionados; se usar DOM, animar o **grupo**, não cada partícula;
+2. partículas com tamanho final em screen-space controlado, sem escalar diretamente com viewport;
+3. animação CSS de grupos por `transform` e, quando necessário, `opacity`;
+4. blur/glow **estático**; não animar blur continuamente;
+5. `pointer-events: none` e `aria-hidden="true"` para decoração;
+6. conteúdo em stacking context superior;
+7. `overflow: hidden|clip` na superfície;
+8. campo de estrelas maior que a área visível e recortado;
+9. primitive reutilizável em vez de dezenas de partículas animadas individualmente.
 
 Não usar `requestAnimationFrame` para um drift simples que CSS resolve. Não animar `top/left/width/height`, background-position pesado ou propriedades que provoquem layout/repaint contínuo sem necessidade.
+
+### SVG — regra preventiva
+
+Se SVG for usado:
+
+- não usar `preserveAspectRatio="none"` em um campo de círculos quando isso transformar pontos em elipses ou ampliar o raio de forma inesperada;
+- preferir coordenadas/geometry que mantenham o tamanho percebido em aproximadamente 0.5–1.8 CSS px;
+- validar visualmente o maior ponto na viewport real;
+- `vector-effect="non-scaling-stroke"` não impede que `r`/geometria preenchida escale: não tratá-lo como proteção de tamanho.
 
 ### React/Motion
 
@@ -209,7 +253,7 @@ Regras:
 
 - animar principalmente `transform`/`opacity`;
 - limitar a 2 grupos animados por superfície como default;
-- partículas ficam agregadas em SVG/camadas, não dezenas/centenas de nós animados individualmente;
+- partículas ficam agregadas em SVG/camadas ou em grupos estáticos, não dezenas/centenas de nós animados individualmente;
 - blur grande é estático e limitado à superfície;
 - reduzir densidade/amplitude em mobile;
 - evitar vários ambientes fortes simultâneos na mesma viewport;
@@ -236,6 +280,9 @@ Em HeroUI, preferir tokens/variables do tema e não hardcode de azul em todas as
 
 Rejeitar:
 
+- partículas grandes o bastante para parecerem círculos/bolhas;
+- raio em `%`, `vw`, `vh` ou unidade de viewBox pequeno que resulte em tamanho dependente da viewport;
+- campo `viewBox 0 0 100 100` ocupando a viewport com `r≈1` para estrelas;
 - partículas sobre campos/tabela/texto;
 - estrelas cobrindo toda a aplicação com a mesma intensidade;
 - todos os cards com constelação;
@@ -256,6 +303,9 @@ Quando `ambient-constellation` estiver ativo, verificar:
 - conteúdo continua sendo o foco principal;
 - no mínimo duas profundidades visuais nas superfícies fortes;
 - períodos não sincronizados;
+- **nenhuma partícula recorrente parece um círculo voador**;
+- maior partícula visual típica `≤ 2 CSS px` em desktop e `≤ 1.5 CSS px` em mobile, salvo exceção deliberada documentada;
+- densidade/overscan suficientes para manter a assinatura mesmo com partículas pequenas;
 - nenhuma partícula intercepta clique/hover/foco;
 - nenhuma mudança de layout causada pelo loop;
 - tabelas/formulários densos continuam limpos;
@@ -269,6 +319,16 @@ Quando `ambient-constellation` estiver ativo, verificar:
 - sem jank perceptível; medir quando houver dúvida;
 - screenshots antes/depois quando houver baseline visual estável.
 
+### Teste visual de escala obrigatório
+
+Em pelo menos uma viewport desktop e uma mobile:
+
+1. observar a tela em 100% de zoom;
+2. confirmar que os pontos leem como poeira/estrelas, não bolhas;
+3. comparar a relação partícula/superfície com a referência HeroUI Pro;
+4. confirmar que a força visual vem do glow + quantidade + camadas;
+5. se um ponto individual chama mais atenção que o conteúdo sem ser um glint deliberado, reduzir tamanho/opacidade antes de aprovar.
+
 ## Registro no projeto
 
 Quando ativo, registrar:
@@ -277,6 +337,7 @@ Quando ativo, registrar:
 Motion Profile: ambient
 Ambient Surface Profile: ambient-constellation
 Constellation Intensity: strong
+Particle scale: micro, screen-space bounded
 Dense content: clean islands; constellation remains in shell/header/perimeter
 Reduced motion: static constellation fallback
 ```
@@ -288,6 +349,7 @@ Para HeroUI novo, esses valores são inferidos automaticamente salvo exceção e
 Referências usadas para esta política:
 
 - HeroUI OSS `pro-banner.tsx`, `floating-stars.tsx`, `pro-title.tsx` e `global.css` — padrão visual/motion público do banner Pro;
+- inspeção da implementação oficial em 2026-08-25 — card 288px, hero 180px, `FloatingStars` 760.706×637.702 em `scale-50`, drift 12s/15s e micro-opacidades;
 - HeroUI v3 license — Apache-2.0;
 - web.dev — high-performance CSS animations: priorizar `transform` e `opacity`;
 - MDN — `prefers-reduced-motion` e otimização de animações;


### PR DESCRIPTION
## Problema corrigido
A política anterior permitia interpretar `strong` como partículas maiores. Isso produziu no Centro de Administração círculos visíveis e exagerados quando um SVG `0 0 100 100` era escalado para superfícies grandes.

## Referência oficial auditada
Foi inspecionada a implementação pública atual do banner/modal HeroUI Pro em `heroui-inc/heroui`:
- card 288px / área visual 180px;
- `FloatingStars` ~760.706×637.702 dentro de `scale-50`;
- overscan efetivo ~1.32× largura / ~1.77× altura;
- micro-partículas com opacidades baixas;
- duas camadas em 12s/15s e drift visual próximo de 20px.

## Mudanças na Factory
- partículas comuns passam a ser tratadas como microestrelas em screen-space (~0.6–1.5px);
- maior partícula típica limitada a <=2px desktop e <=1.5px mobile;
- `strong` passa a vir de densidade, glow, área e profundidade, não diâmetro;
- overscan/crop e drift proporcional registrados;
- anti-padrão `viewBox 0 0 100 100` + `r≈1` em superfície grande explicitamente proibido;
- UI Builder atualizado para aplicar e auditar essa regra;
- calibração registrada em documento próprio.

Nenhum código proprietário HeroUI Pro foi incorporado; a Factory mantém primitive própria e usa a implementação pública apenas como referência de proporção e comportamento.