### PR TITLE
HeroUI — auditar também anatomias manuais no redesign nativo

### DIFF
--- a/ui/heroui/HEROUI_NATIVE_REDESIGN_CONTRACT.md
+++ b/ui/heroui/HEROUI_NATIVE_REDESIGN_CONTRACT.md
@@ -4,7 +4,7 @@
 
 Quando HeroUI for escolhido explicitamente como linguagem principal — especialmente quando o usuário pedir que a interface pareça criada do zero em HeroUI — a implementação deve ser **nativamente HeroUI**, não uma camada de compatibilidade sobre uma arquitetura visual anterior.
 
-Este contrato complementa `README.md`, `../AMBIENT_CONSTELLATION_PROFILE.md` e `../MOTION_POLICY.md`.
+Este contrato complementa `README.md`, `../AMBIENT_CONSTELLATION_PROFILE.md`, `../MOTION_POLICY.md` e `TEMPORAL_MOTION_QA.md`.
 
 ## Regra de reconstrução limpa
 
@@ -12,11 +12,12 @@ Em redesign explícito de um produto existente para HeroUI:
 
 1. preservar regras de negócio, contratos, autenticação, autorização, dados, rotas e integrações;
 2. reconstruir a **árvore de apresentação** a partir da anatomia HeroUI v3;
-3. usar diretamente componentes e compound components oficiais (`Card`, `Surface`, `Alert`, `Table`, `Chip`, `Avatar`, `Drawer`, `Input`, `Spinner`, `Skeleton`, `ScrollShadow`, etc.) quando a capacidade existir;
+3. usar diretamente componentes e compound components oficiais (`Breadcrumbs`, `ListBox`, `SearchField`, `Kbd`, `Popover`, `Dropdown`, `Card`, `Surface`, `Alert`, `Table`, `Chip`, `Avatar`, `Drawer`, `Spinner`, `Skeleton`, `ProgressBar`, `ScrollShadow`, etc.) quando a capacidade existir;
 4. remover facades/adapters cujo objetivo seja manter APIs de outro design system (`CardHeader`, `Badge`, `Button variant=default`, `asChild`, wrappers de shadcn/Radix, etc.);
 5. remover arquivos, classes e dependências do design system anterior quando não tiverem consumidor real;
 6. componentes locais continuam permitidos quando representam **padrões de produto** (ex.: `AmbientConstellation`, `LivingSurface`, visualização acadêmica), mas não devem fingir a API de shadcn/ReUI para esconder HeroUI por baixo;
-7. preferir a composição compound do HeroUI v3 a copiar anatomias anteriores.
+7. preferir a composição compound do HeroUI v3 a copiar anatomias anteriores;
+8. depois de remover dependências/facades, executar também a **auditoria de substituição de componentes** descrita abaixo.
 
 ### Gate obrigatório de limpeza
 
@@ -33,6 +34,35 @@ Auditar especificamente:
 
 Se o objetivo é redesign “do zero”, **alterar os imports e a composição é parte do trabalho**, não regressão.
 
+## Auditoria de substituição de componentes
+
+Remover `shadcn`, `Radix`, ReUI ou facades **não basta**. Um sistema pode continuar visualmente antigo quando mantém a mesma anatomia manual usando `div`, `span`, links e CSS próprios.
+
+Depois da limpeza de dependências, comparar cada padrão visível com o catálogo HeroUI atual e substituir implementações manuais quando existir equivalente semântico adequado.
+
+Exemplos obrigatórios de auditoria:
+
+| Padrão manual/legado | Preferência HeroUI v3 |
+| --- | --- |
+| `Centro / Página` montado com spans | `Breadcrumbs` + `Breadcrumbs.Item` |
+| tecla `Ctrl K` desenhada com `<kbd>` próprio | `Kbd`, `Kbd.Abbr`, `Kbd.Content` |
+| sidebar feita com links + classes de selected | `ListBox`/coleção HeroUI + `ScrollShadow` |
+| busca composta por input + popup absoluto | `SearchField` + `Popover` + `ListBox` |
+| bloco avatar/nome/botão sair montado à mão | `Avatar` + `Dropdown`/Menu |
+| lista de sinais ou registros com divisores manuais | `Table`, `ListBox` ou coleção HeroUI conforme semântica |
+| percentual/cobertura desenhado à mão | `ProgressBar`, `Meter` ou `ProgressCircle` |
+| mensagem/status institucional como card genérico | `Alert` + `Chip` conforme semântica |
+| menu mobile customizado | `Drawer` compound |
+
+### Regra de decisão
+
+1. Se HeroUI possui componente com a semântica correta, usar o componente nativo.
+2. Se o componente oficial não resolve a necessidade, compor primitives HeroUI.
+3. Só então criar componente local.
+4. Componente local não deve reproduzir uma API antiga por conveniência.
+
+O gate de redesign deve procurar **resíduos visuais**, não apenas imports antigos.
+
 ## Hierarquia HeroUI recomendada
 
 A interface deve explorar níveis semânticos do ecossistema:
@@ -41,37 +71,65 @@ A interface deve explorar níveis semânticos do ecossistema:
 - `Card` compound para unidades de informação;
 - `Alert` para estados institucionais/validação;
 - `Chip` para status e categorias;
+- `Breadcrumbs` para localização hierárquica;
+- `ListBox` para coleções navegáveis/selecionáveis;
+- `SearchField` + `Popover` para busca;
+- `Dropdown` para ações de conta e menus contextuais;
+- `Kbd` para atalhos;
 - `Table` compound para dados estruturados;
+- `ProgressBar`/`Meter`/`ProgressCircle` para cobertura, estado quantitativo e progresso;
 - `ScrollShadow` para navegação/áreas roláveis;
 - `Drawer`/overlays HeroUI para mobile;
 - `Spinner`, `Skeleton`, `Progress*` para espera;
 - `Button` e `Link` nativos para ações/navegação;
 - tokens `surface`, `surface-secondary`, `surface-tertiary`, `overlay`, `accent`, `muted`, `success`, `warning`, `danger` como semântica principal.
 
-Não transformar toda a aplicação em cards idênticos. Usar `Surface` e espaços negativos para criar hierarquia.
+Não transformar toda a aplicação em cards idênticos. Usar `Surface`, coleções e espaços negativos para criar hierarquia.
 
-## Ambient Constellation — correção de movimento proporcional
+## Ambient Constellation — referência canônica atual
 
-A referência HeroUI Pro deve ser reproduzida por **proporção percebida**, não por copiar valores fixos isolados.
+A referência observável deve ser reproduzida por **proporção percebida**, sem copiar SVG/assets do HeroUI.
 
-No modal de referência, o campo visível tem cerca de 288×180 px e o drift percebido fica em torno de 20 px. Isso representa aproximadamente:
+Snapshot público auditado em 2026-08-25:
 
-- ~7% da largura visível;
-- ~11% da altura visível;
-- ~5% do campo de estrelas com overscan.
+- repositório: `heroui-inc/heroui`;
+- commit auditado: `1d2164e7b9a60221e39501081f0fe4f6c564bccf`;
+- modal/banner: `apps/docs/src/app/[lang]/(home)/components/pro-banner.tsx`;
+- estrelas: `apps/docs/src/app/[lang]/(home)/components/floating-stars.tsx`;
+- keyframes: `apps/docs/src/app/global.css`.
 
-Portanto, usar `20px` como amplitude fixa em uma viewport de 1200–1600 px torna o movimento praticamente invisível e **não é fiel à referência**.
+Características públicas observadas no modal Pro atual:
 
-### Regra revisada
+- card: `288px` de largura;
+- área superior do efeito: `180px` de altura;
+- gradiente base: `#E9E9FF` → `#CCE5F1`;
+- glow: `#5DD0E7` → `#7300FF`;
+- campo natural de estrelas: aproximadamente `760.706 × 637.702px`;
+- o campo é centralizado e renderizado com `scale-50` dentro do recorte do banner;
+- camada forward: `12s ease-in-out infinite`;
+- camada reverse: `15s ease-in-out infinite`;
+- excursão no keyframe oficial: aproximadamente `40px` por eixo, em sentidos opostos;
+- estrelas brancas, muito pequenas, com opacidades variadas.
 
-- tamanho das partículas continua fixo em screen-space (microestrelas, normalmente 0.5–1.5 CSS px);
-- **o deslocamento do grupo pode ser proporcional à superfície**;
-- em superfícies fortes, preferir drift relativo de aproximadamente `4–6%` do campo com overscan, ou valor equivalente perceptível;
-- limitar amplitudes extremas por contexto/performance, mas não reduzir a ponto de o usuário não conseguir perceber o drift após alguns segundos;
-- ciclos de ~12 s e ~15 s continuam baseline, em direções opostas/defasadas;
-- o movimento deve ser verificável em vídeo, captura temporal ou comparação de frames, não apenas pela presença de `animation:` no CSS.
+### Regra de reprodução
 
-Em shell de página inteira, a assinatura deve ser mais fácil de perceber em **zonas delimitadas** (hero, header, waiting/empty panel) e pode usar amplitude maior no campo global. Não depender de um único campo muito transparente cobrindo 1440 px.
+- **não copiar o SVG oficial**; gerar partículas próprias;
+- usar a paleta acima como referência quando o produto pedir fidelidade ao modal HeroUI Pro;
+- manter partículas em screen-space, normalmente `0.45–1.5 CSS px`;
+- aumentar presença por **densidade, contraste, distribuição, glow e excursão**, não criando círculos grandes;
+- em superfícies maiores que o modal, adaptar a excursão proporcionalmente para que o deslocamento continue perceptível após 2–4 segundos;
+- manter pelo menos duas camadas assíncronas/opostas como baseline;
+- glints/cross-sparkles podem existir em pequena proporção, nunca como objetos dominantes;
+- campos fortes devem permanecer atrás do conteúdo, com `pointer-events: none` e `aria-hidden`;
+- dados densos ficam em ilhas limpas.
+
+### Anti-padrões
+
+- usar `20px` ou `40px` fixos em uma viewport de 1200–1600px e declarar o movimento “equivalente”;
+- aumentar o raio/tamanho das partículas para tornar a constelação visível;
+- transformar o campo em bolhas/círculos flutuantes;
+- manter múltiplas fontes CSS concorrentes para a mesma primitive;
+- animar texto/tabelas continuamente para compensar uma atmosfera fraca.
 
 ## Living UI obrigatório para perfil expressive
 
@@ -91,7 +149,8 @@ Aplicar de forma coerente:
 - entrada de página/rota com fade + deslocamento curto;
 - saída não deve bloquear navegação;
 - itens da sidebar têm estado ativo com indicador/realce animado;
-- drawers e busca seguem motion nativo HeroUI.
+- drawers, dropdowns, popovers e busca seguem motion nativo HeroUI;
+- breadcrumb deve refletir a rota real.
 
 ### Superfícies estáticas
 
@@ -108,7 +167,7 @@ Não animar texto, tabela ou conteúdo principal continuamente.
 
 Uma página de espera não deve ser apenas skeletons imóveis. Combinar quando adequado:
 
-- `Spinner`/Skeleton HeroUI;
+- `Spinner`/`Skeleton`/`ProgressBar` HeroUI;
 - constelação visível;
 - halo respirando;
 - mensagens de progresso estáveis;
@@ -135,15 +194,17 @@ Estados vazios e áreas planejadas são superfícies ideais para Living UI:
 
 Para redesign HeroUI nativo + Living UI, validar:
 
-1. nenhum import residual de facade shadcn/ReUI na camada de apresentação;
+1. nenhum import residual de facade shadcn/ReUI/Radix na camada de apresentação;
 2. nenhum diretório de compatibilidade visual sem consumidor necessário;
-3. componentes HeroUI compound aparecem diretamente na composição;
-4. Ambient Constellation claramente perceptível em 100% zoom;
-5. comparar dois frames separados por 2–4 s para provar movimento do campo;
-6. desktop e mobile;
-7. loading, empty/planned, erro/restrição e pelo menos duas rotas normais;
-8. `prefers-reduced-motion`: loops espaciais param e composição permanece legível;
-9. teclado/foco e console;
-10. ausência de jank/overflow.
+3. auditoria de padrões manuais concluída (`Breadcrumbs`, `Kbd`, busca, navegação, perfil, coleções, progresso etc.);
+4. componentes HeroUI compound aparecem diretamente na composição;
+5. Ambient Constellation claramente perceptível em 100% zoom sem partículas grandes;
+6. comparar dois instantes separados por 2–4 s usando **valores computados reais**, conforme `TEMPORAL_MOTION_QA.md`;
+7. desktop e mobile;
+8. loading, empty/planned, erro/restrição e pelo menos duas rotas normais;
+9. `prefers-reduced-motion`: loops espaciais param e composição permanece legível;
+10. teclado/foco, popover/dropdown/drawer e console;
+11. ausência de jank/overflow;
+12. confirmar que CSS antigo ou duplicado da primitive foi removido, não apenas sobrescrito.
 
-A validação deve falhar se o efeito existir tecnicamente mas for imperceptível visualmente.
+A validação deve falhar se o efeito existir tecnicamente mas for imperceptível visualmente, ou se a dependência antiga tiver sido removida mas a anatomia visual manual continuar reproduzindo o design anterior.


### PR DESCRIPTION
Endurece o contrato HeroUI nativo após a revisão visual do Centro.

Mudanças:
- remover dependências/facades antigos deixa de ser suficiente: o gate também procura anatomias manuais que reproduzem a UI antiga;
- registra substituições preferenciais: Breadcrumbs, Kbd, ListBox, SearchField, Popover, Dropdown, Table, ProgressBar/Meter, Drawer;
- registra a referência pública exata do modal Pro atual no repo oficial HeroUI (commit 1d2164e...): #E9E9FF→#CCE5F1, glow #5DD0E7→#7300FF, área 288×180, campo 760.706×637.702 em scale-50, drift 12s/15s com ~40px por eixo;
- proíbe copiar o SVG oficial: a Factory deve gerar partículas próprias e adaptar a proporção percebida;
- reforça fonte CSS única e QA temporal real.

Mudança exclusivamente normativa/documental.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the HeroUI redesign contract with guidance for breadcrumbs, navigation, search, menus, loading states, alerts, and collection components.
  * Added standards for native motion, responsive ambient constellation visuals, reduced-motion behavior, accessibility, focus management, and overlays.
  * Strengthened quality checks for visual consistency, computed styling, route coverage, and removal of legacy or duplicated interface patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->