### PR TITLE
fix(ci): preserve OpenCode pilot task context

### DIFF
--- a/.github/workflows/live-opencode-ollama-pilot.yml
+++ b/.github/workflows/live-opencode-ollama-pilot.yml
@@ -54,6 +54,11 @@ jobs:
 
       - name: Start loopback Ollama and pull the fixed small model
         shell: bash
+        env:
+          # OpenCode's guarded tool schema plus the task prompt exceeds Ollama's
+          # 4K default. Keep enough local context so the task instruction is not
+          # truncated before the model can act on it.
+          OLLAMA_CONTEXT_LENGTH: "16384"
         run: |
           set -euo pipefail
           nohup ollama serve > "${RUNNER_TEMP}/ollama.log" 2>&1 &


### PR DESCRIPTION
## Summary
- give the loopback Ollama server a 16K context for the guarded OpenCode worker
- prevent the 8K provider prompt from being truncated to the 4K default before the task instruction

## Evidence
- first live run 33096971414 reported healthy binaries/model, then no tracked changes
- sanitized Ollama log showed prompt=8240, limit=2050, and explicit input truncation
- Prettier and actionlint pass
- provider tests: 41 pass locally; one Windows-only symlink privilege case remains environment-specific and is covered by Linux CI

No production deployment or final Factory Run merge is included.