### PR TITLE
fix(ci): use agent-capable model for live pilot

### DIFF
--- a/.github/workflows/live-opencode-ollama-pilot.yml
+++ b/.github/workflows/live-opencode-ollama-pilot.yml
@@ -21,7 +21,7 @@ jobs:
       OLLAMA_ARCHIVE_SHA256: 88e0d36bd90121595e5516c84f6ab61b546368fbd2d825b4aae70999c949649d
       OPENCODE_VERSION: v1.18.23
       OPENCODE_ARCHIVE_SHA256: ab7015cd8113e011a461f30a0c2b77d8299a144ff688cb62e93e8802835d7288
-      OPENCODE_OLLAMA_MODEL: qwen2.5-coder:3b
+      OPENCODE_OLLAMA_MODEL: qwen2.5-coder:7b
     steps:
       - name: Checkout trusted Factory main
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
## Summary
- raise the live pilot from qwen2.5-coder:3b to the official tool-capable 7B variant
- keep the existing pinned runtime, 16K context, isolation, permissions, and path constraints unchanged

## Evidence
- run 33097519630 processed the entire 8,240-token prompt without truncation
- the 3B model still ended after 74 generated tokens without invoking the write tool
- Prettier, actionlint, and the deterministic multiagent validator pass

No production deployment or final Factory Run merge is included.