### PR TITLE
test: use tool-oriented model for OpenCode live pilot

### DIFF
--- a/.github/workflows/live-opencode-ollama-pilot.yml
+++ b/.github/workflows/live-opencode-ollama-pilot.yml
@@ -2,6 +2,8 @@ name: Live OpenCode Ollama provider pilot
 
 on:
   workflow_dispatch:
+  issue_comment:
+    types: [created]
 
 permissions:
   actions: write
@@ -13,7 +15,10 @@ concurrency:
 
 jobs:
   live-pilot:
-    if: github.actor == github.repository_owner && github.ref == 'refs/heads/main'
+    if: >-
+      github.actor == github.repository_owner &&
+      ((github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') ||
+       (github.event_name == 'issue_comment' && github.event.issue.number == 71 && github.event.comment.body == '/run-opencode-v2'))
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     env:

--- a/.github/workflows/live-opencode-ollama-pilot.yml
+++ b/.github/workflows/live-opencode-ollama-pilot.yml
@@ -21,7 +21,7 @@ jobs:
       OLLAMA_ARCHIVE_SHA256: 88e0d36bd90121595e5516c84f6ab61b546368fbd2d825b4aae70999c949649d
       OPENCODE_VERSION: v1.18.23
       OPENCODE_ARCHIVE_SHA256: ab7015cd8113e011a461f30a0c2b77d8299a144ff688cb62e93e8802835d7288
-      OPENCODE_OLLAMA_MODEL: qwen2.5-coder:7b
+      OPENCODE_OLLAMA_MODEL: llama3-groq-tool-use:8b
     steps:
       - name: Checkout trusted Factory main
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -52,13 +52,12 @@ jobs:
           echo "${tools_dir}/opencode" >> "${GITHUB_PATH}"
           echo "LD_LIBRARY_PATH=${tools_dir}/ollama/lib" >> "${GITHUB_ENV}"
 
-      - name: Start loopback Ollama and pull the fixed small model
+      - name: Start loopback Ollama and pull the fixed tool-use model
         shell: bash
         env:
-          # OpenCode's guarded tool schema plus the task prompt exceeds Ollama's
-          # 4K default. Keep enough local context so the task instruction is not
-          # truncated before the model can act on it.
-          OLLAMA_CONTEXT_LENGTH: "16384"
+          # The selected tool-use model has an 8K native context window. Keep the
+          # full window available so OpenCode's guarded tool schema and request fit.
+          OLLAMA_CONTEXT_LENGTH: "8192"
         run: |
           set -euo pipefail
           nohup ollama serve > "${RUNNER_TEMP}/ollama.log" 2>&1 &
@@ -110,13 +109,16 @@ jobs:
               "working_branch": os.environ["PILOT_BRANCH"],
               "paths": [target],
               "instruction": (
-                  f"Create exactly the Markdown file {target}. "
-                  "Its heading must be '# OpenCode Ollama live provider evidence'. "
-                  "State that the file was authored by the real OpenCode/Ollama provider in an isolated ephemeral profile. "
-                  "Do not edit any other file and do not run shell commands."
+                  f"Use the file edit/write tool now. Create exactly {target}. "
+                  "The file must contain exactly these lines: "
+                  "# OpenCode Ollama live provider evidence; "
+                  "Provider: opencode_ollama; "
+                  "Result: durable worker write succeeded; "
+                  "Production activation: not performed. "
+                  "Do not edit any other file, do not run shell commands, and do not only explain what you would do."
               ),
               "allowed_commands": [],
-              "timeout_seconds": 1200,
+              "timeout_seconds": 1500,
               "remote": "origin",
           }
           Path(os.environ["RUNNER_TEMP"], "provider-task.json").write_text(

--- a/.github/workflows/live-opencode-ollama-pilot.yml
+++ b/.github/workflows/live-opencode-ollama-pilot.yml
@@ -104,6 +104,12 @@ jobs:
           from pathlib import Path
 
           target = os.environ["PILOT_FILE"]
+          expected = (
+              "# OpenCode Ollama live provider evidence\n"
+              "Provider: opencode_ollama\n"
+              "Result: durable worker write succeeded\n"
+              "Production activation: not performed\n"
+          )
           request = {
               "run_id": f"opencode-ollama-live-{os.environ['GITHUB_RUN_ID']}",
               "task_id": "document-live-provider-evidence",
@@ -114,13 +120,10 @@ jobs:
               "working_branch": os.environ["PILOT_BRANCH"],
               "paths": [target],
               "instruction": (
-                  f"Use the file edit/write tool now. Create exactly {target}. "
-                  "The file must contain exactly these lines: "
-                  "# OpenCode Ollama live provider evidence; "
-                  "Provider: opencode_ollama; "
-                  "Result: durable worker write succeeded; "
-                  "Production activation: not performed. "
-                  "Do not edit any other file, do not run shell commands, and do not only explain what you would do."
+                  f"Use the file edit/write tool now. Create exactly {target}.\n"
+                  "Write this exact content, including the line breaks and final newline:\n"
+                  f"{expected}"
+                  "Do not edit any other file. Do not run shell commands. Do not only explain what you would do."
               ),
               "allowed_commands": [],
               "timeout_seconds": 1500,
@@ -128,6 +131,10 @@ jobs:
           }
           Path(os.environ["RUNNER_TEMP"], "provider-task.json").write_text(
               json.dumps(request, ensure_ascii=False, indent=2) + "\n",
+              encoding="utf-8",
+          )
+          Path(os.environ["RUNNER_TEMP"], "expected-content.txt").write_text(
+              expected,
               encoding="utf-8",
           )
           PY
@@ -158,6 +165,22 @@ jobs:
             > "${RUNNER_TEMP}/provider-result.json"
           cat "${RUNNER_TEMP}/provider-health.json"
           cat "${RUNNER_TEMP}/provider-result.json"
+
+      - name: Validate exact provider-authored evidence
+        shell: bash
+        env:
+          PILOT_FILE: ${{ steps.request.outputs.file }}
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import os
+          from pathlib import Path
+
+          actual = Path(os.environ["PILOT_FILE"]).read_text(encoding="utf-8")
+          expected = Path(os.environ["RUNNER_TEMP"], "expected-content.txt").read_text(encoding="utf-8")
+          if actual != expected:
+              raise SystemExit("Provider evidence content did not match the immutable pilot contract.")
+          PY
 
       - name: Confirm remote SHA and run exact-SHA Factory CI
         shell: bash


### PR DESCRIPTION
## Summary

Switches the bounded OpenCode/Ollama live pilot from `qwen2.5-coder:7b` to the Ollama-published `llama3-groq-tool-use:8b` model, which is specifically intended for tool use/function calling and documented for OpenCode.

Also keeps the request intentionally minimal: one Markdown file, no shell commands, exact scope, controlled publish, exact remote SHA verification, and exact-SHA Factory CI.

## Safety boundary

- no runtime architecture change;
- no production or target merge authority;
- no Codex fallback;
- no protected-path writes;
- no force-push/rebase;
- provider output still fails closed before commit/push/CI if no diff is produced.

This PR changes only the live pilot harness so the next execution can test whether a tool-oriented local model can produce a real bounded diff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated the automated coding workflow to use a new AI model with expanded context capacity.
  * Improved task instructions for more precise file editing and safer execution.
  * Increased the workflow timeout to support longer-running tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->