### PR TITLE
test: run OpenCode live pilot v3 with Qwen3 4B

### DIFF
--- a/.github/workflows/live-opencode-ollama-pilot.yml
+++ b/.github/workflows/live-opencode-ollama-pilot.yml
@@ -10,15 +10,15 @@ permissions:
   contents: write
 
 concurrency:
-  group: ${{ (github.event_name == 'workflow_dispatch' || (github.event_name == 'issue_comment' && github.event.issue.number == 71 && github.event.comment.body == '/run-opencode-v2')) && 'live-opencode-ollama-provider-pilot' || format('live-opencode-ollama-noop-{0}', github.run_id) }}
-  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'issue_comment' && github.event.issue.number == 71 && github.event.comment.body == '/run-opencode-v2') }}
+  group: ${{ (github.event_name == 'workflow_dispatch' || (github.event_name == 'issue_comment' && github.event.issue.number == 76 && github.event.comment.body == '/run-opencode-v3')) && 'live-opencode-ollama-provider-pilot' || format('live-opencode-ollama-noop-{0}', github.run_id) }}
+  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'issue_comment' && github.event.issue.number == 76 && github.event.comment.body == '/run-opencode-v3') }}
 
 jobs:
   live-pilot:
     if: >-
       github.actor == github.repository_owner &&
       ((github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') ||
-       (github.event_name == 'issue_comment' && github.event.issue.number == 71 && github.event.comment.body == '/run-opencode-v2'))
+       (github.event_name == 'issue_comment' && github.event.issue.number == 76 && github.event.comment.body == '/run-opencode-v3'))
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     env:
@@ -26,7 +26,7 @@ jobs:
       OLLAMA_ARCHIVE_SHA256: 88e0d36bd90121595e5516c84f6ab61b546368fbd2d825b4aae70999c949649d
       OPENCODE_VERSION: v1.18.23
       OPENCODE_ARCHIVE_SHA256: ab7015cd8113e011a461f30a0c2b77d8299a144ff688cb62e93e8802835d7288
-      OPENCODE_OLLAMA_MODEL: llama3-groq-tool-use:8b
+      OPENCODE_OLLAMA_MODEL: qwen3:4b
     steps:
       - name: Checkout trusted Factory main
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -60,9 +60,9 @@ jobs:
       - name: Start loopback Ollama and pull the fixed tool-use model
         shell: bash
         env:
-          # The selected tool-use model has an 8K native context window. Keep the
-          # full window available so OpenCode's guarded tool schema and request fit.
-          OLLAMA_CONTEXT_LENGTH: "8192"
+          # Keep a bounded 16K window for the guarded OpenCode request. Qwen3:4b
+          # is published by Ollama with substantially more native context capacity.
+          OLLAMA_CONTEXT_LENGTH: "16384"
         run: |
           set -euo pipefail
           nohup ollama serve > "${RUNNER_TEMP}/ollama.log" 2>&1 &


### PR DESCRIPTION
## Summary

Creates the immutable v3 live proof harness for issue #76 after v2 failed closed with a healthy runtime but no model-authored tool call.

Only the live pilot harness changes:
- owner-authorized trigger moves from issue #71 `/run-opencode-v2` to issue #76 `/run-opencode-v3`;
- local model changes from `llama3-groq-tool-use:8b` to Ollama-published `qwen3:4b`;
- bounded Ollama context changes to 16K, still far below the model's published capacity;
- all provider permissions, exact one-file scope, trusted commit/push path, exact-SHA CI, target-merge prohibition, production prohibition, and Codex prohibition remain unchanged.

No runtime security boundary is relaxed. No target merge or production activation is performed by this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the pilot workflow to respond to the new issue and command trigger.
  * Switched the pilot AI model to `qwen3:4b`.
  * Increased the Ollama context length from 8,192 to 16,384 tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->