### PR TITLE
test: run OpenCode live pilot v4 with Qwen3 Instruct

### DIFF
--- a/.github/workflows/live-opencode-ollama-pilot.yml
+++ b/.github/workflows/live-opencode-ollama-pilot.yml
@@ -10,15 +10,15 @@ permissions:
   contents: write
 
 concurrency:
-  group: ${{ (github.event_name == 'workflow_dispatch' || (github.event_name == 'issue_comment' && github.event.issue.number == 76 && github.event.comment.body == '/run-opencode-v3')) && 'live-opencode-ollama-provider-pilot' || format('live-opencode-ollama-noop-{0}', github.run_id) }}
-  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'issue_comment' && github.event.issue.number == 76 && github.event.comment.body == '/run-opencode-v3') }}
+  group: ${{ (github.event_name == 'workflow_dispatch' || (github.event_name == 'issue_comment' && github.event.issue.number == 78 && github.event.comment.body == '/run-opencode-v4')) && 'live-opencode-ollama-provider-pilot' || format('live-opencode-ollama-noop-{0}', github.run_id) }}
+  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'issue_comment' && github.event.issue.number == 78 && github.event.comment.body == '/run-opencode-v4') }}
 
 jobs:
   live-pilot:
     if: >-
       github.actor == github.repository_owner &&
       ((github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') ||
-       (github.event_name == 'issue_comment' && github.event.issue.number == 76 && github.event.comment.body == '/run-opencode-v3'))
+       (github.event_name == 'issue_comment' && github.event.issue.number == 78 && github.event.comment.body == '/run-opencode-v4'))
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     env:
@@ -26,7 +26,7 @@ jobs:
       OLLAMA_ARCHIVE_SHA256: 88e0d36bd90121595e5516c84f6ab61b546368fbd2d825b4aae70999c949649d
       OPENCODE_VERSION: v1.18.23
       OPENCODE_ARCHIVE_SHA256: ab7015cd8113e011a461f30a0c2b77d8299a144ff688cb62e93e8802835d7288
-      OPENCODE_OLLAMA_MODEL: qwen3:4b
+      OPENCODE_OLLAMA_MODEL: qwen3:4b-instruct
     steps:
       - name: Checkout trusted Factory main
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -60,8 +60,8 @@ jobs:
       - name: Start loopback Ollama and pull the fixed tool-use model
         shell: bash
         env:
-          # Keep a bounded 16K window for the guarded OpenCode request. Qwen3:4b
-          # is published by Ollama with substantially more native context capacity.
+          # Keep a bounded 16K window for the guarded OpenCode request. The
+          # Qwen3 4B Instruct Ollama template explicitly supports tool calls.
           OLLAMA_CONTEXT_LENGTH: "16384"
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary

Creates the immutable v4 OpenCode/Ollama live proof for issue #78 after the hybrid Qwen3 4B v3 remained inside model execution beyond the bounded operational threshold.

Changes only the live pilot harness:
- trigger: issue #78 `/run-opencode-v4`;
- model: `qwen3:4b-instruct`;
- keeps the bounded 16K local context;
- preserves all existing provider permissions, one-file scope, no provider shell, trusted commit/push, exact-SHA CI, no target merge, no production activation, and no Codex fallback.

The Ollama-published Qwen3 4B Instruct template explicitly carries function/tool-call formatting. No runtime security boundary is relaxed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the live OpenCode Ollama pilot to use the newer `/run-opencode-v4` trigger for issue 78.
  - Switched the pilot to the Qwen3 4B Instruct model.
  - Updated concurrency handling and usage notes to reflect the new pilot configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->