### PR TITLE
fix: minimize OpenCode tools for create-only workers

### DIFF
--- a/engine/providers/opencode_ollama.py
+++ b/engine/providers/opencode_ollama.py
@@ -271,11 +271,38 @@ class OpenCodeOllamaAdapter:
         }
 
     def tool_config(self, request: ProviderTaskRequest) -> dict[str, bool]:
-        """Hide unavailable tools so local models do not pay for denied schemas.
+        """Expose only capabilities the bounded task can actually need.
 
-        Permission remains the authoritative security boundary. This visibility layer is
-        deliberately stricter and removes tools that automatic workers can never use.
+        Permission remains the authoritative security boundary. For a task with no
+        control-plane commands whose declared paths do not yet exist, the worker is
+        creation-only: advertising a single write schema reduces local-model prompt
+        cost and removes ambiguous tool choices without granting any new authority.
         """
+        create_only = (
+            not request.normalized_commands
+            and bool(request.normalized_paths)
+            and all(
+                "*" not in scope and not (request.worktree / scope).exists()
+                for scope in request.normalized_paths
+            )
+        )
+        if create_only:
+            return {
+                "bash": False,
+                "edit": False,
+                "write": True,
+                "read": False,
+                "grep": False,
+                "glob": False,
+                "patch": False,
+                "lsp": False,
+                "skill": False,
+                "todowrite": False,
+                "webfetch": False,
+                "websearch": False,
+                "question": False,
+                "task": False,
+            }
         return {
             "bash": bool(request.normalized_commands),
             "edit": True,

--- a/tests/multiagent/test_opencode_create_only_tools.py
+++ b/tests/multiagent/test_opencode_create_only_tools.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from engine.provider_runtime import ProviderTaskRequest
+from engine.providers.opencode_ollama import OpenCodeOllamaAdapter
+
+
+class OpenCodeCreateOnlyToolTests(unittest.TestCase):
+    def test_new_file_without_commands_exposes_only_write_capability(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            worktree = root / "worktree"
+            profile = root / "profile"
+            worktree.mkdir()
+            profile.mkdir()
+            request = ProviderTaskRequest.from_mapping({
+                "run_id": "create-only",
+                "task_id": "evidence",
+                "repository": "owner/repo",
+                "worktree": str(worktree),
+                "integration_branch": "factory/create-only",
+                "target_branch": "main",
+                "working_branch": "factory/create-only/evidence",
+                "paths": ["pilots/live/result.md"],
+                "instruction": "Create exactly the requested evidence file.",
+                "allowed_commands": [],
+            })
+            config = OpenCodeOllamaAdapter(
+                model="functiongemma", profile_home=profile
+            ).opencode_config(request)
+
+        visible = {name for name, enabled in config["tools"].items() if enabled}
+        self.assertEqual(visible, {"write"})
+        self.assertEqual(config["permission"]["edit"]["pilots/live/result.md"], "allow")
+        self.assertEqual(config["permission"]["edit"][".github/**"], "deny")
+
+    def test_existing_file_keeps_read_edit_and_search_tools_visible(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            worktree = root / "worktree"
+            profile = root / "profile"
+            worktree.mkdir()
+            profile.mkdir()
+            existing = worktree / "docs" / "result.md"
+            existing.parent.mkdir()
+            existing.write_text("existing\n", encoding="utf-8")
+            request = ProviderTaskRequest.from_mapping({
+                "run_id": "edit-existing",
+                "task_id": "evidence",
+                "repository": "owner/repo",
+                "worktree": str(worktree),
+                "integration_branch": "factory/edit-existing",
+                "target_branch": "main",
+                "working_branch": "factory/edit-existing/evidence",
+                "paths": ["docs/result.md"],
+                "instruction": "Update the requested evidence file.",
+                "allowed_commands": [],
+            })
+            tools = OpenCodeOllamaAdapter(
+                model="functiongemma", profile_home=profile
+            ).tool_config(request)
+
+        self.assertTrue(tools["write"])
+        self.assertTrue(tools["edit"])
+        self.assertTrue(tools["read"])
+        self.assertTrue(tools["grep"])
+        self.assertTrue(tools["glob"])
+        self.assertTrue(tools["patch"])
+        self.assertFalse(tools["bash"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/multiagent/test_provider_adapters.py
+++ b/tests/multiagent/test_provider_adapters.py
@@ -155,8 +155,8 @@ class ProviderAdapterTests(unittest.TestCase):
             ).opencode_config(request)
         self.assertFalse(config["tools"]["bash"])
         self.assertTrue(config["tools"]["write"])
-        self.assertTrue(config["tools"]["edit"])
-        self.assertTrue(config["tools"]["read"])
+        self.assertFalse(config["tools"]["edit"])
+        self.assertFalse(config["tools"]["read"])
         self.assertFalse(config["tools"]["todowrite"])
         self.assertFalse(config["tools"]["lsp"])
 


### PR DESCRIPTION
## Summary

Minimizes the tool schema advertised to bounded local OpenCode/Ollama workers when the task is deterministically creation-only: no control-plane commands and all declared exact paths are currently absent.

For that narrow case the model sees only `write`. The authoritative permission contract is unchanged: edits remain scope-bounded, protected paths remain denied, external directories/web/task/skill remain denied, and the trusted runtime alone performs commit/push.

Existing-file and command-bearing tasks keep the broader existing tool visibility. Adds focused regressions for both create-only and existing-file paths.

This addresses live pilot evidence where healthy Qwen models consumed ~5.6K prompt tokens largely from the OpenCode/tool surface and returned no tool call. It reduces prompt cost and ambiguity without granting any new capability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Creation-only tasks now expose only the file-writing capability needed to create new files.
  * Existing-file tasks retain access to editing, reading, searching, and patching tools while command execution remains disabled.

* **Bug Fixes**
  * Improved tool permissions for tasks without approved commands, preventing unnecessary file access and command execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->