### PR TITLE
fix: require single OpenCode tool through loopback Ollama shim

### DIFF
--- a/.github/workflows/live-opencode-ollama-pilot.yml
+++ b/.github/workflows/live-opencode-ollama-pilot.yml
@@ -10,15 +10,15 @@ permissions:
   contents: write
 
 concurrency:
-  group: ${{ (github.event_name == 'workflow_dispatch' || (github.event_name == 'issue_comment' && github.event.issue.number == 81 && github.event.comment.body == '/run-opencode-v5')) && 'live-opencode-ollama-provider-pilot' || format('live-opencode-ollama-noop-{0}', github.run_id) }}
-  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'issue_comment' && github.event.issue.number == 81 && github.event.comment.body == '/run-opencode-v5') }}
+  group: ${{ (github.event_name == 'workflow_dispatch' || (github.event_name == 'issue_comment' && github.event.issue.number == 84 && github.event.comment.body == '/run-opencode-v6')) && 'live-opencode-ollama-provider-pilot' || format('live-opencode-ollama-noop-{0}', github.run_id) }}
+  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'issue_comment' && github.event.issue.number == 84 && github.event.comment.body == '/run-opencode-v6') }}
 
 jobs:
   live-pilot:
     if: >-
       github.actor == github.repository_owner &&
       ((github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') ||
-       (github.event_name == 'issue_comment' && github.event.issue.number == 81 && github.event.comment.body == '/run-opencode-v5'))
+       (github.event_name == 'issue_comment' && github.event.issue.number == 84 && github.event.comment.body == '/run-opencode-v6'))
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     env:
@@ -40,43 +40,51 @@ jobs:
           set -euo pipefail
           tools_dir="${RUNNER_TEMP}/factory-tools"
           mkdir -p "${tools_dir}/ollama" "${tools_dir}/opencode"
-
           curl --fail --location --retry 3 \
             "https://github.com/ollama/ollama/releases/download/${OLLAMA_VERSION}/ollama-linux-amd64.tar.zst" \
             --output "${RUNNER_TEMP}/ollama-linux-amd64.tar.zst"
           echo "${OLLAMA_ARCHIVE_SHA256}  ${RUNNER_TEMP}/ollama-linux-amd64.tar.zst" | sha256sum --check --strict
           tar --use-compress-program=unzstd -xf "${RUNNER_TEMP}/ollama-linux-amd64.tar.zst" -C "${tools_dir}/ollama"
-
           curl --fail --location --retry 3 \
             "https://github.com/anomalyco/opencode/releases/download/${OPENCODE_VERSION}/opencode-linux-x64.tar.gz" \
             --output "${RUNNER_TEMP}/opencode-linux-x64.tar.gz"
           echo "${OPENCODE_ARCHIVE_SHA256}  ${RUNNER_TEMP}/opencode-linux-x64.tar.gz" | sha256sum --check --strict
           tar -xzf "${RUNNER_TEMP}/opencode-linux-x64.tar.gz" -C "${tools_dir}/opencode"
-
           echo "${tools_dir}/ollama/bin" >> "${GITHUB_PATH}"
           echo "${tools_dir}/opencode" >> "${GITHUB_PATH}"
           echo "LD_LIBRARY_PATH=${tools_dir}/ollama/lib" >> "${GITHUB_ENV}"
 
-      - name: Start loopback Ollama and pull the fixed tool-use model
+      - name: Start loopback Ollama and required-tool proxy
         shell: bash
         env:
-          # FunctionGemma is a 270M single-turn function-calling model with a
-          # 32K window. Keep the live Factory request bounded to 8K.
           OLLAMA_CONTEXT_LENGTH: "8192"
         run: |
           set -euo pipefail
           nohup ollama serve > "${RUNNER_TEMP}/ollama.log" 2>&1 &
           for attempt in $(seq 1 30); do
-            if ollama list >/dev/null 2>&1; then
-              break
-            fi
-            if [ "${attempt}" -eq 30 ]; then
-              echo "Ollama did not become ready on loopback." >&2
-              exit 1
-            fi
+            if ollama list >/dev/null 2>&1; then break; fi
+            if [ "${attempt}" -eq 30 ]; then exit 1; fi
             sleep 2
           done
           ollama pull "${OPENCODE_OLLAMA_MODEL}"
+          nohup python scripts/ollama_tool_proxy.py \
+            --listen-host 127.0.0.1 \
+            --listen-port 11435 \
+            --upstream http://127.0.0.1:11434/v1 \
+            --expected-tool write \
+            --audit-file "${RUNNER_TEMP}/tool-proxy-audit.json" \
+            > "${RUNNER_TEMP}/tool-proxy.log" 2>&1 &
+          python - <<'PY'
+          import socket, time
+          for _ in range(30):
+              try:
+                  with socket.create_connection(("127.0.0.1", 11435), timeout=1):
+                      break
+              except OSError:
+                  time.sleep(1)
+          else:
+              raise SystemExit("required-tool proxy did not bind to loopback")
+          PY
           ollama list
           opencode --version
 
@@ -88,22 +96,15 @@ jobs:
           PILOT_FILE: pilots/live/opencode-ollama/run-${{ github.run_id }}-${{ github.run_attempt }}.md
         run: |
           set -euo pipefail
-          if git ls-remote --exit-code origin "refs/heads/${PILOT_BRANCH}" >/dev/null 2>&1; then
-            echo "Worker branch already exists: ${PILOT_BRANCH}" >&2
-            exit 1
-          fi
+          if git ls-remote --exit-code origin "refs/heads/${PILOT_BRANCH}" >/dev/null 2>&1; then exit 1; fi
           git switch -c "${PILOT_BRANCH}"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          mkdir -p "${RUNNER_TEMP}/opencode-profile"
-          mkdir -p "$(dirname "${PILOT_FILE}")"
-
+          mkdir -p "${RUNNER_TEMP}/opencode-profile" "$(dirname "${PILOT_FILE}")"
           export PILOT_BRANCH PILOT_FILE
           python - <<'PY'
-          import json
-          import os
+          import json, os
           from pathlib import Path
-
           target = os.environ["PILOT_FILE"]
           expected = (
               "# OpenCode Ollama live provider evidence\n"
@@ -130,40 +131,27 @@ jobs:
               "timeout_seconds": 600,
               "remote": "origin",
           }
-          Path(os.environ["RUNNER_TEMP"], "provider-task.json").write_text(
-              json.dumps(request, ensure_ascii=False, indent=2) + "\n",
-              encoding="utf-8",
-          )
-          Path(os.environ["RUNNER_TEMP"], "expected-content.txt").write_text(
-              expected,
-              encoding="utf-8",
-          )
+          Path(os.environ["RUNNER_TEMP"], "provider-task.json").write_text(json.dumps(request, indent=2) + "\n", encoding="utf-8")
+          Path(os.environ["RUNNER_TEMP"], "expected-content.txt").write_text(expected, encoding="utf-8")
           PY
-
           echo "branch=${PILOT_BRANCH}" >> "${GITHUB_OUTPUT}"
           echo "file=${PILOT_FILE}" >> "${GITHUB_OUTPUT}"
           echo "profile=${RUNNER_TEMP}/opencode-profile" >> "${GITHUB_OUTPUT}"
 
-      - name: Execute and publish through the real provider runtime
-        id: provider
+      - name: Execute and publish through real OpenCode and trusted runtime
         shell: bash
         env:
           OPENCODE_PROFILE_HOME: ${{ steps.request.outputs.profile }}
-          OLLAMA_BASE_URL: http://127.0.0.1:11434/v1
+          OLLAMA_BASE_URL: http://127.0.0.1:11435/v1
         run: |
           set -euo pipefail
           python scripts/provider_worker.py probe \
-            --provider opencode_ollama \
-            --model "${OPENCODE_OLLAMA_MODEL}" \
-            --profile-home "${OPENCODE_PROFILE_HOME}" \
-            > "${RUNNER_TEMP}/provider-health.json"
+            --provider opencode_ollama --model "${OPENCODE_OLLAMA_MODEL}" \
+            --profile-home "${OPENCODE_PROFILE_HOME}" > "${RUNNER_TEMP}/provider-health.json"
           python scripts/provider_worker.py run \
-            --provider opencode_ollama \
-            --model "${OPENCODE_OLLAMA_MODEL}" \
-            --profile-home "${OPENCODE_PROFILE_HOME}" \
-            --publish \
-            "${RUNNER_TEMP}/provider-task.json" \
-            > "${RUNNER_TEMP}/provider-result.json"
+            --provider opencode_ollama --model "${OPENCODE_OLLAMA_MODEL}" \
+            --profile-home "${OPENCODE_PROFILE_HOME}" --publish \
+            "${RUNNER_TEMP}/provider-task.json" > "${RUNNER_TEMP}/provider-result.json"
           cat "${RUNNER_TEMP}/provider-health.json"
           cat "${RUNNER_TEMP}/provider-result.json"
 
@@ -174,13 +162,14 @@ jobs:
         run: |
           set -euo pipefail
           python - <<'PY'
-          import os
+          import json, os
           from pathlib import Path
-
           actual = Path(os.environ["PILOT_FILE"]).read_text(encoding="utf-8")
           expected = Path(os.environ["RUNNER_TEMP"], "expected-content.txt").read_text(encoding="utf-8")
-          if actual != expected:
-              raise SystemExit("Provider evidence content did not match the immutable pilot contract.")
+          if actual != expected: raise SystemExit("provider evidence content mismatch")
+          audit = json.loads(Path(os.environ["RUNNER_TEMP"], "tool-proxy-audit.json").read_text())
+          if audit["accepted"] < 1 or audit["rewritten"] < 1 or audit["forwarded"] < 1 or audit["rejected"] != 0:
+              raise SystemExit(f"unexpected tool proxy audit counters: {audit}")
           PY
 
       - name: Confirm remote SHA and run exact-SHA Factory CI
@@ -190,32 +179,19 @@ jobs:
           PILOT_BRANCH: ${{ steps.request.outputs.branch }}
         run: |
           set -euo pipefail
-          result_sha=$(python -c 'import json, os; print(json.load(open(os.path.join(os.environ["RUNNER_TEMP"], "provider-result.json"), encoding="utf-8"))["evidence"]["commit_sha"])')
+          result_sha=$(python -c 'import json, os; print(json.load(open(os.path.join(os.environ["RUNNER_TEMP"], "provider-result.json")))["evidence"]["commit_sha"])')
           remote_sha=$(git ls-remote origin "refs/heads/${PILOT_BRANCH}" | awk '{print $1}')
-          test -n "${remote_sha}"
-          test "${remote_sha}" = "${result_sha}"
-
+          test -n "${remote_sha}" && test "${remote_sha}" = "${result_sha}"
           gh workflow run validate-multiagent-execution.yml --ref "${PILOT_BRANCH}"
           run_id=""
           for attempt in $(seq 1 30); do
-            run_id=$(gh run list \
-              --workflow validate-multiagent-execution.yml \
-              --branch "${PILOT_BRANCH}" \
-              --event workflow_dispatch \
-              --limit 10 \
-              --json databaseId,headSha \
-              --jq ".[] | select(.headSha == \"${remote_sha}\") | .databaseId" \
-              | head -n 1)
-            if [ -n "${run_id}" ]; then
-              break
-            fi
+            run_id=$(gh run list --workflow validate-multiagent-execution.yml --branch "${PILOT_BRANCH}" --event workflow_dispatch --limit 10 --json databaseId,headSha --jq ".[] | select(.headSha == \"${remote_sha}\") | .databaseId" | head -n 1)
+            if [ -n "${run_id}" ]; then break; fi
             sleep 2
           done
           test -n "${run_id}"
           gh run watch "${run_id}" --exit-status
-          printf '{"branch":"%s","remote_sha":"%s","ci_run_id":"%s","ci_url":"https://github.com/%s/actions/runs/%s"}\n' \
-            "${PILOT_BRANCH}" "${remote_sha}" "${run_id}" "${GITHUB_REPOSITORY}" "${run_id}" \
-            > "${RUNNER_TEMP}/durable-evidence.json"
+          printf '{"branch":"%s","remote_sha":"%s","ci_run_id":"%s"}\n' "${PILOT_BRANCH}" "${remote_sha}" "${run_id}" > "${RUNNER_TEMP}/durable-evidence.json"
 
       - name: Publish sanitized pilot evidence
         if: always()
@@ -226,6 +202,8 @@ jobs:
             ${{ runner.temp }}/provider-health.json
             ${{ runner.temp }}/provider-result.json
             ${{ runner.temp }}/durable-evidence.json
+            ${{ runner.temp }}/tool-proxy-audit.json
+            ${{ runner.temp }}/tool-proxy.log
             ${{ runner.temp }}/ollama.log
           if-no-files-found: warn
           retention-days: 30

--- a/engine/ollama_tool_proxy.py
+++ b/engine/ollama_tool_proxy.py
@@ -1,19 +1,7 @@
 from __future__ import annotations
 
-import json
-import os
-import tempfile
-import threading
-import urllib.error
 import urllib.parse
-import urllib.request
-from dataclasses import dataclass, field
-from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
-from pathlib import Path
 from typing import Any, Mapping
-
-MAX_REQUEST_BYTES = 2 * 1024 * 1024
-SENSITIVE_HEADERS = frozenset({"authorization", "proxy-authorization", "x-api-key"})
 
 
 def validate_loopback_base_url(value: str) -> str:
@@ -29,11 +17,15 @@ def validate_loopback_base_url(value: str) -> str:
         or parsed.fragment
         or parsed.path not in {"", "/v1"}
     ):
-        raise ValueError("tool proxy upstream must be credential-free loopback HTTP with optional /v1 path")
+        raise ValueError(
+            "tool proxy upstream must be credential-free loopback HTTP with optional /v1 path"
+        )
     return raw
 
 
-def rewrite_single_tool_request(payload: Mapping[str, Any], *, expected_tool: str) -> dict[str, Any]:
+def rewrite_single_tool_request(
+    payload: Mapping[str, Any], *, expected_tool: str
+) -> dict[str, Any]:
     if not isinstance(payload, Mapping):
         raise ValueError("chat request must be a JSON object")
     messages = payload.get("messages")
@@ -54,179 +46,3 @@ def rewrite_single_tool_request(payload: Mapping[str, Any], *, expected_tool: st
     rewritten = dict(payload)
     rewritten["tool_choice"] = "required"
     return rewritten
-
-
-@dataclass
-class ProxyAudit:
-    expected_tool: str
-    accepted: int = 0
-    rejected: int = 0
-    rewritten: int = 0
-    forwarded: int = 0
-    upstream_errors: int = 0
-    last_status: int | None = None
-    _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
-
-    def snapshot(self) -> dict[str, Any]:
-        with self._lock:
-            return {
-                "schema_version": 1,
-                "expected_tool": self.expected_tool,
-                "accepted": self.accepted,
-                "rejected": self.rejected,
-                "rewritten": self.rewritten,
-                "forwarded": self.forwarded,
-                "upstream_errors": self.upstream_errors,
-                "last_status": self.last_status,
-            }
-
-    def mutate(self, **increments: int) -> None:
-        with self._lock:
-            for name, value in increments.items():
-                if name == "last_status":
-                    self.last_status = value
-                else:
-                    setattr(self, name, getattr(self, name) + value)
-
-
-def write_audit(path: Path | None, audit: ProxyAudit) -> None:
-    if path is None:
-        return
-    path.parent.mkdir(parents=True, exist_ok=True)
-    payload = json.dumps(audit.snapshot(), sort_keys=True, indent=2) + "\n"
-    with tempfile.NamedTemporaryFile("w", encoding="utf-8", dir=path.parent, delete=False) as handle:
-        handle.write(payload)
-        temporary = Path(handle.name)
-    os.replace(temporary, path)
-
-
-class RequiredToolProxyServer(ThreadingHTTPServer):
-    daemon_threads = True
-
-    def __init__(
-        self,
-        server_address: tuple[str, int],
-        *,
-        upstream_base_url: str,
-        expected_tool: str,
-        audit_file: Path | None = None,
-    ) -> None:
-        host, _ = server_address
-        if host not in {"127.0.0.1", "localhost", "::1"}:
-            raise ValueError("tool proxy must bind to loopback")
-        self.upstream_base_url = validate_loopback_base_url(upstream_base_url)
-        self.expected_tool = expected_tool
-        if not expected_tool or any(char.isspace() for char in expected_tool):
-            raise ValueError("expected tool name is invalid")
-        self.audit = ProxyAudit(expected_tool=expected_tool)
-        self.audit_file = audit_file
-        super().__init__(server_address, RequiredToolProxyHandler)
-        write_audit(self.audit_file, self.audit)
-
-
-class RequiredToolProxyHandler(BaseHTTPRequestHandler):
-    protocol_version = "HTTP/1.1"
-    server: RequiredToolProxyServer
-
-    def log_message(self, format: str, *args: object) -> None:  # noqa: A002
-        return
-
-    def _reject(self, status: int = 400) -> None:
-        self.server.audit.mutate(rejected=1, last_status=status)
-        write_audit(self.server.audit_file, self.server.audit)
-        body = b'{"error":"required-tool proxy rejected request"}\n'
-        self.send_response(status)
-        self.send_header("Content-Type", "application/json")
-        self.send_header("Content-Length", str(len(body)))
-        self.send_header("Connection", "close")
-        self.end_headers()
-        self.wfile.write(body)
-        self.close_connection = True
-
-    def do_GET(self) -> None:  # noqa: N802
-        self._reject(405)
-
-    def do_POST(self) -> None:  # noqa: N802
-        if self.path != "/v1/chat/completions":
-            self._reject(404)
-            return
-        if any(name.lower() in SENSITIVE_HEADERS for name in self.headers.keys()):
-            self._reject(400)
-            return
-        content_type = self.headers.get_content_type()
-        if content_type != "application/json":
-            self._reject(415)
-            return
-        try:
-            length = int(self.headers.get("Content-Length", "0"))
-        except ValueError:
-            self._reject(400)
-            return
-        if length <= 0 or length > MAX_REQUEST_BYTES:
-            self._reject(413)
-            return
-        raw = self.rfile.read(length)
-        try:
-            payload = json.loads(raw)
-            original_choice = payload.get("tool_choice", "auto") if isinstance(payload, dict) else None
-            rewritten = rewrite_single_tool_request(
-                payload, expected_tool=self.server.expected_tool
-            )
-        except (UnicodeDecodeError, json.JSONDecodeError, ValueError):
-            self._reject(400)
-            return
-
-        self.server.audit.mutate(
-            accepted=1,
-            rewritten=1 if original_choice != "required" else 0,
-        )
-        write_audit(self.server.audit_file, self.server.audit)
-        upstream = f"{self.server.upstream_base_url}/chat/completions"
-        request = urllib.request.Request(
-            upstream,
-            data=json.dumps(rewritten, separators=(",", ":")).encode("utf-8"),
-            method="POST",
-            headers={
-                "Content-Type": "application/json",
-                "Accept": self.headers.get("Accept", "application/json"),
-            },
-        )
-        try:
-            response = urllib.request.urlopen(request, timeout=900)
-        except urllib.error.HTTPError as error:
-            self.server.audit.mutate(upstream_errors=1, last_status=error.code)
-            write_audit(self.server.audit_file, self.server.audit)
-            self._send_upstream_error(error.code)
-            return
-        except (urllib.error.URLError, TimeoutError, OSError):
-            self.server.audit.mutate(upstream_errors=1, last_status=502)
-            write_audit(self.server.audit_file, self.server.audit)
-            self._send_upstream_error(502)
-            return
-
-        with response:
-            status = int(response.status)
-            self.server.audit.mutate(forwarded=1, last_status=status)
-            write_audit(self.server.audit_file, self.server.audit)
-            self.send_response(status)
-            self.send_header("Content-Type", response.headers.get("Content-Type", "application/json"))
-            self.send_header("Cache-Control", "no-store")
-            self.send_header("Connection", "close")
-            self.end_headers()
-            while True:
-                chunk = response.read(64 * 1024)
-                if not chunk:
-                    break
-                self.wfile.write(chunk)
-                self.wfile.flush()
-            self.close_connection = True
-
-    def _send_upstream_error(self, status: int) -> None:
-        body = b'{"error":"local Ollama upstream failed"}\n'
-        self.send_response(status)
-        self.send_header("Content-Type", "application/json")
-        self.send_header("Content-Length", str(len(body)))
-        self.send_header("Connection", "close")
-        self.end_headers()
-        self.wfile.write(body)
-        self.close_connection = True

--- a/engine/ollama_tool_proxy.py
+++ b/engine/ollama_tool_proxy.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import threading
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass, field
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any, Mapping
+
+MAX_REQUEST_BYTES = 2 * 1024 * 1024
+SENSITIVE_HEADERS = frozenset({"authorization", "proxy-authorization", "x-api-key"})
+
+
+def validate_loopback_base_url(value: str) -> str:
+    raw = str(value or "").strip().rstrip("/")
+    parsed = urllib.parse.urlparse(raw)
+    if (
+        parsed.scheme != "http"
+        or parsed.hostname not in {"127.0.0.1", "localhost", "::1"}
+        or parsed.username
+        or parsed.password
+        or parsed.params
+        or parsed.query
+        or parsed.fragment
+        or parsed.path not in {"", "/v1"}
+    ):
+        raise ValueError("tool proxy upstream must be credential-free loopback HTTP with optional /v1 path")
+    return raw
+
+
+def rewrite_single_tool_request(payload: Mapping[str, Any], *, expected_tool: str) -> dict[str, Any]:
+    if not isinstance(payload, Mapping):
+        raise ValueError("chat request must be a JSON object")
+    messages = payload.get("messages")
+    if not isinstance(messages, list) or not messages:
+        raise ValueError("chat request requires messages")
+    tools = payload.get("tools")
+    if not isinstance(tools, list) or len(tools) != 1:
+        raise ValueError("required-tool proxy accepts exactly one tool")
+    tool = tools[0]
+    if not isinstance(tool, Mapping) or tool.get("type") != "function":
+        raise ValueError("required-tool proxy accepts one function tool")
+    function = tool.get("function")
+    if not isinstance(function, Mapping) or function.get("name") != expected_tool:
+        raise ValueError("required-tool proxy received an unexpected function tool")
+    choice = payload.get("tool_choice", "auto")
+    if choice not in {"auto", "required"}:
+        raise ValueError("required-tool proxy rejects conflicting tool_choice")
+    rewritten = dict(payload)
+    rewritten["tool_choice"] = "required"
+    return rewritten
+
+
+@dataclass
+class ProxyAudit:
+    expected_tool: str
+    accepted: int = 0
+    rejected: int = 0
+    rewritten: int = 0
+    forwarded: int = 0
+    upstream_errors: int = 0
+    last_status: int | None = None
+    _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
+
+    def snapshot(self) -> dict[str, Any]:
+        with self._lock:
+            return {
+                "schema_version": 1,
+                "expected_tool": self.expected_tool,
+                "accepted": self.accepted,
+                "rejected": self.rejected,
+                "rewritten": self.rewritten,
+                "forwarded": self.forwarded,
+                "upstream_errors": self.upstream_errors,
+                "last_status": self.last_status,
+            }
+
+    def mutate(self, **increments: int) -> None:
+        with self._lock:
+            for name, value in increments.items():
+                if name == "last_status":
+                    self.last_status = value
+                else:
+                    setattr(self, name, getattr(self, name) + value)
+
+
+def write_audit(path: Path | None, audit: ProxyAudit) -> None:
+    if path is None:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(audit.snapshot(), sort_keys=True, indent=2) + "\n"
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", dir=path.parent, delete=False) as handle:
+        handle.write(payload)
+        temporary = Path(handle.name)
+    os.replace(temporary, path)
+
+
+class RequiredToolProxyServer(ThreadingHTTPServer):
+    daemon_threads = True
+
+    def __init__(
+        self,
+        server_address: tuple[str, int],
+        *,
+        upstream_base_url: str,
+        expected_tool: str,
+        audit_file: Path | None = None,
+    ) -> None:
+        host, _ = server_address
+        if host not in {"127.0.0.1", "localhost", "::1"}:
+            raise ValueError("tool proxy must bind to loopback")
+        self.upstream_base_url = validate_loopback_base_url(upstream_base_url)
+        self.expected_tool = expected_tool
+        if not expected_tool or any(char.isspace() for char in expected_tool):
+            raise ValueError("expected tool name is invalid")
+        self.audit = ProxyAudit(expected_tool=expected_tool)
+        self.audit_file = audit_file
+        super().__init__(server_address, RequiredToolProxyHandler)
+        write_audit(self.audit_file, self.audit)
+
+
+class RequiredToolProxyHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+    server: RequiredToolProxyServer
+
+    def log_message(self, format: str, *args: object) -> None:  # noqa: A002
+        return
+
+    def _reject(self, status: int = 400) -> None:
+        self.server.audit.mutate(rejected=1, last_status=status)
+        write_audit(self.server.audit_file, self.server.audit)
+        body = b'{"error":"required-tool proxy rejected request"}\n'
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Connection", "close")
+        self.end_headers()
+        self.wfile.write(body)
+        self.close_connection = True
+
+    def do_GET(self) -> None:  # noqa: N802
+        self._reject(405)
+
+    def do_POST(self) -> None:  # noqa: N802
+        if self.path != "/v1/chat/completions":
+            self._reject(404)
+            return
+        if any(name.lower() in SENSITIVE_HEADERS for name in self.headers.keys()):
+            self._reject(400)
+            return
+        content_type = self.headers.get_content_type()
+        if content_type != "application/json":
+            self._reject(415)
+            return
+        try:
+            length = int(self.headers.get("Content-Length", "0"))
+        except ValueError:
+            self._reject(400)
+            return
+        if length <= 0 or length > MAX_REQUEST_BYTES:
+            self._reject(413)
+            return
+        raw = self.rfile.read(length)
+        try:
+            payload = json.loads(raw)
+            original_choice = payload.get("tool_choice", "auto") if isinstance(payload, dict) else None
+            rewritten = rewrite_single_tool_request(
+                payload, expected_tool=self.server.expected_tool
+            )
+        except (UnicodeDecodeError, json.JSONDecodeError, ValueError):
+            self._reject(400)
+            return
+
+        self.server.audit.mutate(
+            accepted=1,
+            rewritten=1 if original_choice != "required" else 0,
+        )
+        write_audit(self.server.audit_file, self.server.audit)
+        upstream = f"{self.server.upstream_base_url}/chat/completions"
+        request = urllib.request.Request(
+            upstream,
+            data=json.dumps(rewritten, separators=(",", ":")).encode("utf-8"),
+            method="POST",
+            headers={
+                "Content-Type": "application/json",
+                "Accept": self.headers.get("Accept", "application/json"),
+            },
+        )
+        try:
+            response = urllib.request.urlopen(request, timeout=900)
+        except urllib.error.HTTPError as error:
+            self.server.audit.mutate(upstream_errors=1, last_status=error.code)
+            write_audit(self.server.audit_file, self.server.audit)
+            self._send_upstream_error(error.code)
+            return
+        except (urllib.error.URLError, TimeoutError, OSError):
+            self.server.audit.mutate(upstream_errors=1, last_status=502)
+            write_audit(self.server.audit_file, self.server.audit)
+            self._send_upstream_error(502)
+            return
+
+        with response:
+            status = int(response.status)
+            self.server.audit.mutate(forwarded=1, last_status=status)
+            write_audit(self.server.audit_file, self.server.audit)
+            self.send_response(status)
+            self.send_header("Content-Type", response.headers.get("Content-Type", "application/json"))
+            self.send_header("Cache-Control", "no-store")
+            self.send_header("Connection", "close")
+            self.end_headers()
+            while True:
+                chunk = response.read(64 * 1024)
+                if not chunk:
+                    break
+                self.wfile.write(chunk)
+                self.wfile.flush()
+            self.close_connection = True
+
+    def _send_upstream_error(self, status: int) -> None:
+        body = b'{"error":"local Ollama upstream failed"}\n'
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Connection", "close")
+        self.end_headers()
+        self.wfile.write(body)
+        self.close_connection = True

--- a/scripts/ollama_tool_proxy.py
+++ b/scripts/ollama_tool_proxy.py
@@ -2,14 +2,207 @@
 from __future__ import annotations
 
 import argparse
+import json
+import os
 import sys
+import tempfile
+import threading
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
+from typing import Any
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from engine.ollama_tool_proxy import RequiredToolProxyServer  # noqa: E402
+from engine.ollama_tool_proxy import (  # noqa: E402
+    rewrite_single_tool_request,
+    validate_loopback_base_url,
+)
+
+MAX_REQUEST_BYTES = 2 * 1024 * 1024
+SENSITIVE_HEADERS = frozenset({"authorization", "proxy-authorization", "x-api-key"})
+
+
+@dataclass
+class ProxyAudit:
+    expected_tool: str
+    accepted: int = 0
+    rejected: int = 0
+    rewritten: int = 0
+    forwarded: int = 0
+    upstream_errors: int = 0
+    last_status: int | None = None
+    _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
+
+    def snapshot(self) -> dict[str, Any]:
+        with self._lock:
+            return {
+                "schema_version": 1,
+                "expected_tool": self.expected_tool,
+                "accepted": self.accepted,
+                "rejected": self.rejected,
+                "rewritten": self.rewritten,
+                "forwarded": self.forwarded,
+                "upstream_errors": self.upstream_errors,
+                "last_status": self.last_status,
+            }
+
+    def mutate(self, **increments: int) -> None:
+        with self._lock:
+            for name, value in increments.items():
+                if name == "last_status":
+                    self.last_status = value
+                else:
+                    setattr(self, name, getattr(self, name) + value)
+
+
+def write_audit(path: Path | None, audit: ProxyAudit) -> None:
+    if path is None:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(audit.snapshot(), sort_keys=True, indent=2) + "\n"
+    with tempfile.NamedTemporaryFile(
+        "w", encoding="utf-8", dir=path.parent, delete=False
+    ) as handle:
+        handle.write(payload)
+        temporary = Path(handle.name)
+    os.replace(temporary, path)
+
+
+class RequiredToolProxyServer(ThreadingHTTPServer):
+    daemon_threads = True
+
+    def __init__(
+        self,
+        server_address: tuple[str, int],
+        *,
+        upstream_base_url: str,
+        expected_tool: str,
+        audit_file: Path | None = None,
+    ) -> None:
+        host, _ = server_address
+        if host not in {"127.0.0.1", "localhost", "::1"}:
+            raise ValueError("tool proxy must bind to loopback")
+        self.upstream_base_url = validate_loopback_base_url(upstream_base_url)
+        self.expected_tool = expected_tool
+        if not expected_tool or any(char.isspace() for char in expected_tool):
+            raise ValueError("expected tool name is invalid")
+        self.audit = ProxyAudit(expected_tool=expected_tool)
+        self.audit_file = audit_file
+        super().__init__(server_address, RequiredToolProxyHandler)
+        write_audit(self.audit_file, self.audit)
+
+
+class RequiredToolProxyHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+    server: RequiredToolProxyServer
+
+    def log_message(self, format: str, *args: object) -> None:  # noqa: A002
+        return
+
+    def _reject(self, status: int = 400) -> None:
+        self.server.audit.mutate(rejected=1, last_status=status)
+        write_audit(self.server.audit_file, self.server.audit)
+        body = b'{"error":"required-tool proxy rejected request"}\n'
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Connection", "close")
+        self.end_headers()
+        self.wfile.write(body)
+        self.close_connection = True
+
+    def do_GET(self) -> None:  # noqa: N802
+        self._reject(405)
+
+    def do_POST(self) -> None:  # noqa: N802
+        if self.path != "/v1/chat/completions":
+            self._reject(404)
+            return
+        if any(name.lower() in SENSITIVE_HEADERS for name in self.headers.keys()):
+            self._reject(400)
+            return
+        if self.headers.get_content_type() != "application/json":
+            self._reject(415)
+            return
+        try:
+            length = int(self.headers.get("Content-Length", "0"))
+        except ValueError:
+            self._reject(400)
+            return
+        if length <= 0 or length > MAX_REQUEST_BYTES:
+            self._reject(413)
+            return
+        try:
+            payload = json.loads(self.rfile.read(length))
+            original_choice = (
+                payload.get("tool_choice", "auto") if isinstance(payload, dict) else None
+            )
+            rewritten = rewrite_single_tool_request(
+                payload, expected_tool=self.server.expected_tool
+            )
+        except (UnicodeDecodeError, json.JSONDecodeError, ValueError):
+            self._reject(400)
+            return
+
+        self.server.audit.mutate(
+            accepted=1, rewritten=1 if original_choice != "required" else 0
+        )
+        write_audit(self.server.audit_file, self.server.audit)
+        request = urllib.request.Request(
+            f"{self.server.upstream_base_url}/chat/completions",
+            data=json.dumps(rewritten, separators=(",", ":")).encode("utf-8"),
+            method="POST",
+            headers={
+                "Content-Type": "application/json",
+                "Accept": self.headers.get("Accept", "application/json"),
+            },
+        )
+        try:
+            response = urllib.request.urlopen(request, timeout=900)
+        except urllib.error.HTTPError as error:
+            self.server.audit.mutate(upstream_errors=1, last_status=error.code)
+            write_audit(self.server.audit_file, self.server.audit)
+            self._send_upstream_error(error.code)
+            return
+        except (urllib.error.URLError, TimeoutError, OSError):
+            self.server.audit.mutate(upstream_errors=1, last_status=502)
+            write_audit(self.server.audit_file, self.server.audit)
+            self._send_upstream_error(502)
+            return
+
+        with response:
+            status = int(response.status)
+            self.server.audit.mutate(forwarded=1, last_status=status)
+            write_audit(self.server.audit_file, self.server.audit)
+            self.send_response(status)
+            self.send_header(
+                "Content-Type", response.headers.get("Content-Type", "application/json")
+            )
+            self.send_header("Cache-Control", "no-store")
+            self.send_header("Connection", "close")
+            self.end_headers()
+            while True:
+                chunk = response.read(64 * 1024)
+                if not chunk:
+                    break
+                self.wfile.write(chunk)
+                self.wfile.flush()
+            self.close_connection = True
+
+    def _send_upstream_error(self, status: int) -> None:
+        body = b'{"error":"local Ollama upstream failed"}\n'
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Connection", "close")
+        self.end_headers()
+        self.wfile.write(body)
+        self.close_connection = True
 
 
 def parser() -> argparse.ArgumentParser:

--- a/scripts/ollama_tool_proxy.py
+++ b/scripts/ollama_tool_proxy.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from engine.ollama_tool_proxy import RequiredToolProxyServer  # noqa: E402
+
+
+def parser() -> argparse.ArgumentParser:
+    item = argparse.ArgumentParser(
+        description="Fail-closed loopback proxy that requires one OpenAI function tool"
+    )
+    item.add_argument("--listen-host", default="127.0.0.1")
+    item.add_argument("--listen-port", type=int, default=11435)
+    item.add_argument("--upstream", default="http://127.0.0.1:11434/v1")
+    item.add_argument("--expected-tool", required=True)
+    item.add_argument("--audit-file", type=Path)
+    return item
+
+
+def main() -> int:
+    args = parser().parse_args()
+    try:
+        if not 1 <= args.listen_port <= 65535:
+            raise ValueError("listen port must be from 1 through 65535")
+        server = RequiredToolProxyServer(
+            (args.listen_host, args.listen_port),
+            upstream_base_url=args.upstream,
+            expected_tool=args.expected_tool,
+            audit_file=args.audit_file,
+        )
+        print(
+            f"required-tool proxy listening on {args.listen_host}:{server.server_port}; "
+            "upstream=loopback; payload logging=disabled",
+            flush=True,
+        )
+        server.serve_forever(poll_interval=0.25)
+        return 0
+    except (OSError, ValueError) as error:
+        print(f"required-tool proxy failed: {error}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/multiagent/test_ollama_tool_proxy.py
+++ b/tests/multiagent/test_ollama_tool_proxy.py
@@ -45,7 +45,7 @@ class OllamaToolProxyTests(unittest.TestCase):
         )
 
     def test_rejects_zero_multiple_wrong_or_conflicting_tools(self) -> None:
-        cases = []
+        cases = [[]]
         zero = self.base_payload()
         zero["tools"] = []
         cases.append(zero)
@@ -55,6 +55,9 @@ class OllamaToolProxyTests(unittest.TestCase):
         wrong_type = self.base_payload()
         wrong_type["tools"] = [{"type": "web_search"}]
         cases.append(wrong_type)
+        missing_function = self.base_payload()
+        missing_function["tools"] = [{"type": "function", "function": None}]
+        cases.append(missing_function)
         wrong_name = self.base_payload()
         wrong_name["tools"][0]["function"]["name"] = "bash"
         cases.append(wrong_name)
@@ -79,6 +82,7 @@ class OllamaToolProxyTests(unittest.TestCase):
             "http://localhost:11434",
         )
         for value in (
+            "",
             "https://127.0.0.1:11434/v1",
             "http://ollama.example.com:11434/v1",
             "http://user:pass@127.0.0.1:11434/v1",

--- a/tests/multiagent/test_ollama_tool_proxy.py
+++ b/tests/multiagent/test_ollama_tool_proxy.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import unittest
+
+from engine.ollama_tool_proxy import rewrite_single_tool_request, validate_loopback_base_url
+
+
+class OllamaToolProxyTests(unittest.TestCase):
+    def base_payload(self):
+        return {
+            "model": "functiongemma:270m",
+            "messages": [{"role": "user", "content": "create the file"}],
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "write",
+                        "description": "Write a file",
+                        "parameters": {"type": "object"},
+                    },
+                }
+            ],
+            "tool_choice": "auto",
+            "stream": True,
+        }
+
+    def test_rewrites_only_auto_or_missing_choice_to_required(self) -> None:
+        payload = self.base_payload()
+        rewritten = rewrite_single_tool_request(payload, expected_tool="write")
+        self.assertEqual(rewritten["tool_choice"], "required")
+        self.assertEqual(payload["tool_choice"], "auto")
+
+        missing = self.base_payload()
+        missing.pop("tool_choice")
+        self.assertEqual(
+            rewrite_single_tool_request(missing, expected_tool="write")["tool_choice"],
+            "required",
+        )
+
+        already = self.base_payload()
+        already["tool_choice"] = "required"
+        self.assertEqual(
+            rewrite_single_tool_request(already, expected_tool="write")["tool_choice"],
+            "required",
+        )
+
+    def test_rejects_zero_multiple_wrong_or_conflicting_tools(self) -> None:
+        cases = []
+        zero = self.base_payload()
+        zero["tools"] = []
+        cases.append(zero)
+        multiple = self.base_payload()
+        multiple["tools"] = multiple["tools"] * 2
+        cases.append(multiple)
+        wrong_type = self.base_payload()
+        wrong_type["tools"] = [{"type": "web_search"}]
+        cases.append(wrong_type)
+        wrong_name = self.base_payload()
+        wrong_name["tools"][0]["function"]["name"] = "bash"
+        cases.append(wrong_name)
+        conflicting = self.base_payload()
+        conflicting["tool_choice"] = "none"
+        cases.append(conflicting)
+        no_messages = self.base_payload()
+        no_messages["messages"] = []
+        cases.append(no_messages)
+
+        for payload in cases:
+            with self.subTest(payload=payload), self.assertRaises(ValueError):
+                rewrite_single_tool_request(payload, expected_tool="write")
+
+    def test_upstream_is_strictly_credential_free_loopback_http(self) -> None:
+        self.assertEqual(
+            validate_loopback_base_url("http://127.0.0.1:11434/v1/"),
+            "http://127.0.0.1:11434/v1",
+        )
+        self.assertEqual(
+            validate_loopback_base_url("http://localhost:11434"),
+            "http://localhost:11434",
+        )
+        for value in (
+            "https://127.0.0.1:11434/v1",
+            "http://ollama.example.com:11434/v1",
+            "http://user:pass@127.0.0.1:11434/v1",
+            "http://127.0.0.1:11434/api",
+            "http://127.0.0.1:11434/v1?token=x",
+        ):
+            with self.subTest(value=value), self.assertRaises(ValueError):
+                validate_loopback_base_url(value)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a fail-closed loopback-only compatibility shim for the known OpenCode/OpenAI-compatible `tool_choice: auto` gap and wires the immutable v6 proof (#84).

The shim:
- binds only to loopback;
- forwards only `/v1/chat/completions` to a credential-free loopback Ollama upstream;
- rejects credential headers, oversized/non-JSON requests, unsupported paths/methods, zero/multiple/non-function tools, unexpected tool names, and conflicting tool choices;
- for exactly one expected function tool, changes only absent/`auto` tool choice to `required`;
- never logs prompts, messages, tool arguments, headers, or response content;
- persists only bounded audit counters;
- streams the upstream response unchanged.

The v6 live harness keeps FunctionGemma, the profile-local minimal OpenCode agent, production create-only `write` visibility, no provider shell, one-file scope, trusted runtime commit/push, exact remote SHA and exact-SHA CI. No target merge, production activation, protected-path authority or Codex fallback is introduced.

Regression tests cover request rewriting and strict loopback/upstream rejection behavior.