### PR TITLE
fix: expose sanitized OpenCode proxy reject reason

### DIFF
--- a/scripts/ollama_tool_proxy.py
+++ b/scripts/ollama_tool_proxy.py
@@ -25,6 +25,14 @@ from engine.ollama_tool_proxy import (  # noqa: E402
 
 MAX_REQUEST_BYTES = 2 * 1024 * 1024
 SENSITIVE_HEADERS = frozenset({"authorization", "proxy-authorization", "x-api-key"})
+REJECT_REASONS = frozenset({
+    "method",
+    "path",
+    "sensitive_header",
+    "content_type",
+    "content_length",
+    "tool_contract",
+})
 
 
 @dataclass
@@ -36,6 +44,7 @@ class ProxyAudit:
     forwarded: int = 0
     upstream_errors: int = 0
     last_status: int | None = None
+    last_reject_reason: str | None = None
     _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
 
     def snapshot(self) -> dict[str, Any]:
@@ -49,13 +58,14 @@ class ProxyAudit:
                 "forwarded": self.forwarded,
                 "upstream_errors": self.upstream_errors,
                 "last_status": self.last_status,
+                "last_reject_reason": self.last_reject_reason,
             }
 
-    def mutate(self, **increments: int) -> None:
+    def mutate(self, **updates: Any) -> None:
         with self._lock:
-            for name, value in increments.items():
-                if name == "last_status":
-                    self.last_status = value
+            for name, value in updates.items():
+                if name in {"last_status", "last_reject_reason"}:
+                    setattr(self, name, value)
                 else:
                     setattr(self, name, getattr(self, name) + value)
 
@@ -104,8 +114,14 @@ class RequiredToolProxyHandler(BaseHTTPRequestHandler):
     def log_message(self, format: str, *args: object) -> None:  # noqa: A002
         return
 
-    def _reject(self, status: int = 400) -> None:
-        self.server.audit.mutate(rejected=1, last_status=status)
+    def _reject(self, status: int, reason: str) -> None:
+        if reason not in REJECT_REASONS:
+            reason = "tool_contract"
+        self.server.audit.mutate(
+            rejected=1,
+            last_status=status,
+            last_reject_reason=reason,
+        )
         write_audit(self.server.audit_file, self.server.audit)
         body = b'{"error":"required-tool proxy rejected request"}\n'
         self.send_response(status)
@@ -117,25 +133,25 @@ class RequiredToolProxyHandler(BaseHTTPRequestHandler):
         self.close_connection = True
 
     def do_GET(self) -> None:  # noqa: N802
-        self._reject(405)
+        self._reject(405, "method")
 
     def do_POST(self) -> None:  # noqa: N802
         if self.path != "/v1/chat/completions":
-            self._reject(404)
+            self._reject(404, "path")
             return
         if any(name.lower() in SENSITIVE_HEADERS for name in self.headers.keys()):
-            self._reject(400)
+            self._reject(400, "sensitive_header")
             return
         if self.headers.get_content_type() != "application/json":
-            self._reject(415)
+            self._reject(415, "content_type")
             return
         try:
             length = int(self.headers.get("Content-Length", "0"))
         except ValueError:
-            self._reject(400)
+            self._reject(400, "content_length")
             return
         if length <= 0 or length > MAX_REQUEST_BYTES:
-            self._reject(413)
+            self._reject(413, "content_length")
             return
         try:
             payload = json.loads(self.rfile.read(length))
@@ -146,11 +162,13 @@ class RequiredToolProxyHandler(BaseHTTPRequestHandler):
                 payload, expected_tool=self.server.expected_tool
             )
         except (UnicodeDecodeError, json.JSONDecodeError, ValueError):
-            self._reject(400)
+            self._reject(400, "tool_contract")
             return
 
         self.server.audit.mutate(
-            accepted=1, rewritten=1 if original_choice != "required" else 0
+            accepted=1,
+            rewritten=1 if original_choice != "required" else 0,
+            last_reject_reason=None,
         )
         write_audit(self.server.audit_file, self.server.audit)
         request = urllib.request.Request(

--- a/tests/multiagent/test_ollama_tool_proxy_audit.py
+++ b/tests/multiagent/test_ollama_tool_proxy_audit.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import unittest
+
+from scripts.ollama_tool_proxy import ProxyAudit, REJECT_REASONS
+
+
+class OllamaToolProxyAuditTests(unittest.TestCase):
+    def test_reject_reason_is_bounded_and_contains_no_request_content(self) -> None:
+        self.assertEqual(
+            REJECT_REASONS,
+            {
+                "method",
+                "path",
+                "sensitive_header",
+                "content_type",
+                "content_length",
+                "tool_contract",
+            },
+        )
+        audit = ProxyAudit(expected_tool="write")
+        audit.mutate(rejected=1, last_status=400, last_reject_reason="tool_contract")
+        snapshot = audit.snapshot()
+
+        self.assertEqual(snapshot["last_reject_reason"], "tool_contract")
+        self.assertEqual(snapshot["rejected"], 1)
+        self.assertNotIn("prompt", snapshot)
+        self.assertNotIn("headers", snapshot)
+        self.assertNotIn("arguments", snapshot)
+
+    def test_acceptance_can_clear_only_the_last_reason(self) -> None:
+        audit = ProxyAudit(expected_tool="write", rejected=1, last_reject_reason="path")
+        audit.mutate(accepted=1, rewritten=1, last_reject_reason=None)
+        snapshot = audit.snapshot()
+
+        self.assertEqual(snapshot["accepted"], 1)
+        self.assertEqual(snapshot["rewritten"], 1)
+        self.assertEqual(snapshot["rejected"], 1)
+        self.assertIsNone(snapshot["last_reject_reason"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a bounded `last_reject_reason` enum to the loopback required-tool proxy audit so failed live proofs can distinguish path/header/content/tool-contract rejection without logging prompts, messages, tool arguments, header values, credentials, or response bodies.

Allowed reasons are fixed to: `method`, `path`, `sensitive_header`, `content_type`, `content_length`, and `tool_contract`.

The proxy behavior and v6 immutable contract are otherwise unchanged. Adds regressions proving the audit contains no request content and can clear only the last reason after acceptance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detailed rejection reasons to proxy audit snapshots, including method, path, header, content type, content length, and tool contract violations.
  * Accepted requests now clear the most recent rejection reason while preserving rejection totals.

* **Tests**
  * Added coverage for rejection reason reporting, audit data privacy, and acceptance behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->