### PR TITLE
fix: classify OpenCode tool-contract rejection safely

### DIFF
--- a/scripts/ollama_tool_proxy.py
+++ b/scripts/ollama_tool_proxy.py
@@ -25,12 +25,22 @@ from engine.ollama_tool_proxy import (  # noqa: E402
 
 MAX_REQUEST_BYTES = 2 * 1024 * 1024
 SENSITIVE_HEADERS = frozenset({"authorization", "proxy-authorization", "x-api-key"})
+TOOL_CONTRACT_REASON_BY_MESSAGE = {
+    "chat request must be a JSON object": "tool_payload",
+    "chat request requires messages": "tool_messages",
+    "required-tool proxy accepts exactly one tool": "tool_count",
+    "required-tool proxy accepts one function tool": "tool_type",
+    "required-tool proxy received an unexpected function tool": "tool_name",
+    "required-tool proxy rejects conflicting tool_choice": "tool_choice",
+}
 REJECT_REASONS = frozenset({
     "method",
     "path",
     "sensitive_header",
     "content_type",
     "content_length",
+    "json_payload",
+    *TOOL_CONTRACT_REASON_BY_MESSAGE.values(),
     "tool_contract",
 })
 
@@ -153,16 +163,24 @@ class RequiredToolProxyHandler(BaseHTTPRequestHandler):
         if length <= 0 or length > MAX_REQUEST_BYTES:
             self._reject(413, "content_length")
             return
+        raw = self.rfile.read(length)
         try:
-            payload = json.loads(self.rfile.read(length))
-            original_choice = (
-                payload.get("tool_choice", "auto") if isinstance(payload, dict) else None
-            )
+            payload = json.loads(raw)
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            self._reject(400, "json_payload")
+            return
+        original_choice = (
+            payload.get("tool_choice", "auto") if isinstance(payload, dict) else None
+        )
+        try:
             rewritten = rewrite_single_tool_request(
                 payload, expected_tool=self.server.expected_tool
             )
-        except (UnicodeDecodeError, json.JSONDecodeError, ValueError):
-            self._reject(400, "tool_contract")
+        except ValueError as error:
+            self._reject(
+                400,
+                TOOL_CONTRACT_REASON_BY_MESSAGE.get(str(error), "tool_contract"),
+            )
             return
 
         self.server.audit.mutate(

--- a/tests/multiagent/test_ollama_tool_proxy_audit.py
+++ b/tests/multiagent/test_ollama_tool_proxy_audit.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 import unittest
 
-from scripts.ollama_tool_proxy import ProxyAudit, REJECT_REASONS
+from scripts.ollama_tool_proxy import (
+    ProxyAudit,
+    REJECT_REASONS,
+    TOOL_CONTRACT_REASON_BY_MESSAGE,
+)
 
 
 class OllamaToolProxyAuditTests(unittest.TestCase):
@@ -15,14 +19,32 @@ class OllamaToolProxyAuditTests(unittest.TestCase):
                 "sensitive_header",
                 "content_type",
                 "content_length",
+                "json_payload",
+                "tool_payload",
+                "tool_messages",
+                "tool_count",
+                "tool_type",
+                "tool_name",
+                "tool_choice",
                 "tool_contract",
             },
         )
+        self.assertEqual(
+            set(TOOL_CONTRACT_REASON_BY_MESSAGE.values()),
+            {
+                "tool_payload",
+                "tool_messages",
+                "tool_count",
+                "tool_type",
+                "tool_name",
+                "tool_choice",
+            },
+        )
         audit = ProxyAudit(expected_tool="write")
-        audit.mutate(rejected=1, last_status=400, last_reject_reason="tool_contract")
+        audit.mutate(rejected=1, last_status=400, last_reject_reason="tool_count")
         snapshot = audit.snapshot()
 
-        self.assertEqual(snapshot["last_reject_reason"], "tool_contract")
+        self.assertEqual(snapshot["last_reject_reason"], "tool_count")
         self.assertEqual(snapshot["rejected"], 1)
         self.assertNotIn("prompt", snapshot)
         self.assertNotIn("headers", snapshot)


### PR DESCRIPTION
## Summary

Refines the v6 loopback proxy audit so a `tool_contract` failure is classified into fixed non-sensitive reason codes: payload shape, messages, tool count, tool type, tool name, or tool choice. Invalid JSON is classified separately.

No request content, tool arguments, headers, credential values, prompt text, response body, or unexpected tool name is persisted. The immutable v6 provider contract and proxy behavior remain unchanged; this change only makes the fail-closed evidence actionable.

Adds regression coverage for the bounded reason set and mapping.