### PR TITLE
fix: filter OpenCode payload to the expected write tool

### DIFF
--- a/.github/workflows/live-opencode-ollama-pilot.yml
+++ b/.github/workflows/live-opencode-ollama-pilot.yml
@@ -10,15 +10,15 @@ permissions:
   contents: write
 
 concurrency:
-  group: ${{ (github.event_name == 'workflow_dispatch' || (github.event_name == 'issue_comment' && github.event.issue.number == 84 && github.event.comment.body == '/run-opencode-v6')) && 'live-opencode-ollama-provider-pilot' || format('live-opencode-ollama-noop-{0}', github.run_id) }}
-  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'issue_comment' && github.event.issue.number == 84 && github.event.comment.body == '/run-opencode-v6') }}
+  group: ${{ (github.event_name == 'workflow_dispatch' || (github.event_name == 'issue_comment' && github.event.issue.number == 88 && github.event.comment.body == '/run-opencode-v7')) && 'live-opencode-ollama-provider-pilot' || format('live-opencode-ollama-noop-{0}', github.run_id) }}
+  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'issue_comment' && github.event.issue.number == 88 && github.event.comment.body == '/run-opencode-v7') }}
 
 jobs:
   live-pilot:
     if: >-
       github.actor == github.repository_owner &&
       ((github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') ||
-       (github.event_name == 'issue_comment' && github.event.issue.number == 84 && github.event.comment.body == '/run-opencode-v6'))
+       (github.event_name == 'issue_comment' && github.event.issue.number == 88 && github.event.comment.body == '/run-opencode-v7'))
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     env:
@@ -54,7 +54,7 @@ jobs:
           echo "${tools_dir}/opencode" >> "${GITHUB_PATH}"
           echo "LD_LIBRARY_PATH=${tools_dir}/ollama/lib" >> "${GITHUB_ENV}"
 
-      - name: Start loopback Ollama and required-tool proxy
+      - name: Start loopback Ollama and filtered required-tool proxy
         shell: bash
         env:
           OLLAMA_CONTEXT_LENGTH: "8192"
@@ -166,9 +166,17 @@ jobs:
           from pathlib import Path
           actual = Path(os.environ["PILOT_FILE"]).read_text(encoding="utf-8")
           expected = Path(os.environ["RUNNER_TEMP"], "expected-content.txt").read_text(encoding="utf-8")
-          if actual != expected: raise SystemExit("provider evidence content mismatch")
+          if actual != expected:
+              raise SystemExit("provider evidence content mismatch")
           audit = json.loads(Path(os.environ["RUNNER_TEMP"], "tool-proxy-audit.json").read_text())
-          if audit["accepted"] < 1 or audit["rewritten"] < 1 or audit["forwarded"] < 1 or audit["rejected"] != 0:
+          if (
+              audit["accepted"] < 1
+              or audit["rewritten"] < 1
+              or audit["forwarded"] < 1
+              or audit["rejected"] != 0
+              or audit["tools_received"] < 2
+              or audit["tools_discarded"] < 1
+          ):
               raise SystemExit(f"unexpected tool proxy audit counters: {audit}")
           PY
 

--- a/engine/ollama_tool_proxy.py
+++ b/engine/ollama_tool_proxy.py
@@ -32,17 +32,27 @@ def rewrite_single_tool_request(
     if not isinstance(messages, list) or not messages:
         raise ValueError("chat request requires messages")
     tools = payload.get("tools")
-    if not isinstance(tools, list) or len(tools) != 1:
-        raise ValueError("required-tool proxy accepts exactly one tool")
-    tool = tools[0]
-    if not isinstance(tool, Mapping) or tool.get("type") != "function":
-        raise ValueError("required-tool proxy accepts one function tool")
-    function = tool.get("function")
-    if not isinstance(function, Mapping) or function.get("name") != expected_tool:
-        raise ValueError("required-tool proxy received an unexpected function tool")
+    if not isinstance(tools, list) or not tools:
+        raise ValueError("required-tool proxy requires a non-empty tool list")
+
+    expected_matches: list[Mapping[str, Any]] = []
+    for tool in tools:
+        if not isinstance(tool, Mapping) or tool.get("type") != "function":
+            raise ValueError("required-tool proxy accepts only function tools")
+        function = tool.get("function")
+        if not isinstance(function, Mapping):
+            raise ValueError("required-tool proxy accepts only function tools")
+        if function.get("name") == expected_tool:
+            expected_matches.append(tool)
+
+    if len(expected_matches) != 1:
+        raise ValueError("required-tool proxy requires exactly one expected function tool")
+
     choice = payload.get("tool_choice", "auto")
     if choice not in {"auto", "required"}:
         raise ValueError("required-tool proxy rejects conflicting tool_choice")
+
     rewritten = dict(payload)
+    rewritten["tools"] = [dict(expected_matches[0])]
     rewritten["tool_choice"] = "required"
     return rewritten

--- a/scripts/ollama_tool_proxy.py
+++ b/scripts/ollama_tool_proxy.py
@@ -28,9 +28,9 @@ SENSITIVE_HEADERS = frozenset({"authorization", "proxy-authorization", "x-api-ke
 TOOL_CONTRACT_REASON_BY_MESSAGE = {
     "chat request must be a JSON object": "tool_payload",
     "chat request requires messages": "tool_messages",
-    "required-tool proxy accepts exactly one tool": "tool_count",
-    "required-tool proxy accepts one function tool": "tool_type",
-    "required-tool proxy received an unexpected function tool": "tool_name",
+    "required-tool proxy requires a non-empty tool list": "tool_count",
+    "required-tool proxy accepts only function tools": "tool_type",
+    "required-tool proxy requires exactly one expected function tool": "tool_name",
     "required-tool proxy rejects conflicting tool_choice": "tool_choice",
 }
 REJECT_REASONS = frozenset({
@@ -53,6 +53,8 @@ class ProxyAudit:
     rewritten: int = 0
     forwarded: int = 0
     upstream_errors: int = 0
+    tools_received: int = 0
+    tools_discarded: int = 0
     last_status: int | None = None
     last_reject_reason: str | None = None
     _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
@@ -67,6 +69,8 @@ class ProxyAudit:
                 "rewritten": self.rewritten,
                 "forwarded": self.forwarded,
                 "upstream_errors": self.upstream_errors,
+                "tools_received": self.tools_received,
+                "tools_discarded": self.tools_discarded,
                 "last_status": self.last_status,
                 "last_reject_reason": self.last_reject_reason,
             }
@@ -172,6 +176,8 @@ class RequiredToolProxyHandler(BaseHTTPRequestHandler):
         original_choice = (
             payload.get("tool_choice", "auto") if isinstance(payload, dict) else None
         )
+        tools = payload.get("tools") if isinstance(payload, dict) else None
+        received_tool_count = len(tools) if isinstance(tools, list) else 0
         try:
             rewritten = rewrite_single_tool_request(
                 payload, expected_tool=self.server.expected_tool
@@ -183,9 +189,12 @@ class RequiredToolProxyHandler(BaseHTTPRequestHandler):
             )
             return
 
+        retained_tool_count = len(rewritten.get("tools", []))
         self.server.audit.mutate(
             accepted=1,
-            rewritten=1 if original_choice != "required" else 0,
+            rewritten=1 if original_choice != "required" or received_tool_count != 1 else 0,
+            tools_received=received_tool_count,
+            tools_discarded=max(received_tool_count - retained_tool_count, 0),
             last_reject_reason=None,
         )
         write_audit(self.server.audit_file, self.server.audit)
@@ -243,7 +252,7 @@ class RequiredToolProxyHandler(BaseHTTPRequestHandler):
 
 def parser() -> argparse.ArgumentParser:
     item = argparse.ArgumentParser(
-        description="Fail-closed loopback proxy that requires one OpenAI function tool"
+        description="Fail-closed loopback proxy that filters to one expected OpenAI function tool"
     )
     item.add_argument("--listen-host", default="127.0.0.1")
     item.add_argument("--listen-port", type=int, default=11435)

--- a/tests/multiagent/test_ollama_tool_proxy.py
+++ b/tests/multiagent/test_ollama_tool_proxy.py
@@ -24,12 +24,38 @@ class OllamaToolProxyTests(unittest.TestCase):
             "stream": True,
         }
 
-    def test_rewrites_only_auto_or_missing_choice_to_required(self) -> None:
+    def test_filters_extra_function_tools_and_forces_expected_tool_required(self) -> None:
         payload = self.base_payload()
+        payload["tools"].extend(
+            [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "read",
+                        "description": "Read a file",
+                        "parameters": {"type": "object"},
+                    },
+                },
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "bash",
+                        "description": "Run a command",
+                        "parameters": {"type": "object"},
+                    },
+                },
+            ]
+        )
+
         rewritten = rewrite_single_tool_request(payload, expected_tool="write")
+
         self.assertEqual(rewritten["tool_choice"], "required")
+        self.assertEqual(len(rewritten["tools"]), 1)
+        self.assertEqual(rewritten["tools"][0]["function"]["name"], "write")
+        self.assertEqual(len(payload["tools"]), 3)
         self.assertEqual(payload["tool_choice"], "auto")
 
+    def test_rewrites_missing_or_required_choice_without_expanding_authority(self) -> None:
         missing = self.base_payload()
         missing.pop("tool_choice")
         self.assertEqual(
@@ -44,23 +70,23 @@ class OllamaToolProxyTests(unittest.TestCase):
             "required",
         )
 
-    def test_rejects_zero_multiple_wrong_or_conflicting_tools(self) -> None:
-        cases = [[]]
+    def test_rejects_missing_duplicate_non_function_or_conflicting_expected_tool(self) -> None:
+        cases = []
         zero = self.base_payload()
         zero["tools"] = []
         cases.append(zero)
-        multiple = self.base_payload()
-        multiple["tools"] = multiple["tools"] * 2
-        cases.append(multiple)
+        missing_expected = self.base_payload()
+        missing_expected["tools"][0]["function"]["name"] = "read"
+        cases.append(missing_expected)
+        duplicate_expected = self.base_payload()
+        duplicate_expected["tools"] = duplicate_expected["tools"] * 2
+        cases.append(duplicate_expected)
         wrong_type = self.base_payload()
-        wrong_type["tools"] = [{"type": "web_search"}]
+        wrong_type["tools"].append({"type": "web_search"})
         cases.append(wrong_type)
         missing_function = self.base_payload()
-        missing_function["tools"] = [{"type": "function", "function": None}]
+        missing_function["tools"].append({"type": "function", "function": None})
         cases.append(missing_function)
-        wrong_name = self.base_payload()
-        wrong_name["tools"][0]["function"]["name"] = "bash"
-        cases.append(wrong_name)
         conflicting = self.base_payload()
         conflicting["tool_choice"] = "none"
         cases.append(conflicting)

--- a/tests/multiagent/test_ollama_tool_proxy_audit.py
+++ b/tests/multiagent/test_ollama_tool_proxy_audit.py
@@ -50,15 +50,24 @@ class OllamaToolProxyAuditTests(unittest.TestCase):
         self.assertNotIn("headers", snapshot)
         self.assertNotIn("arguments", snapshot)
 
-    def test_acceptance_can_clear_only_the_last_reason(self) -> None:
+    def test_acceptance_tracks_only_tool_counts_and_can_clear_last_reason(self) -> None:
         audit = ProxyAudit(expected_tool="write", rejected=1, last_reject_reason="path")
-        audit.mutate(accepted=1, rewritten=1, last_reject_reason=None)
+        audit.mutate(
+            accepted=1,
+            rewritten=1,
+            tools_received=7,
+            tools_discarded=6,
+            last_reject_reason=None,
+        )
         snapshot = audit.snapshot()
 
         self.assertEqual(snapshot["accepted"], 1)
         self.assertEqual(snapshot["rewritten"], 1)
         self.assertEqual(snapshot["rejected"], 1)
+        self.assertEqual(snapshot["tools_received"], 7)
+        self.assertEqual(snapshot["tools_discarded"], 6)
         self.assertIsNone(snapshot["last_reject_reason"])
+        self.assertNotIn("tool_names", snapshot)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Implements the immutable v7 contract from issue #88. The loopback compatibility shim now treats OpenCode's extra tool schemas as excess model authority: it requires a non-empty function-tool list containing exactly one `write`, discards every other function schema before forwarding, and forces the filtered single-tool turn to `required`.

Missing/duplicate `write`, non-function entries, credentials, unsupported paths/methods and conflicting tool choices still fail closed. The shim never executes a tool, never widens adapter permissions, and persists only aggregate tool counts (received/discarded), not tool names or arguments.

The v7 live harness requires audit evidence that extra schemas were actually removed, then still requires the exact provider-authored file, trusted runtime commit/push, remote SHA equality and exact-SHA CI. No target merge, production activation or Codex fallback is introduced.

Regression tests cover extra-tool filtering and all failure cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool requests can now include multiple tools while forwarding only the intended one.
  * Tool selection is enforced when missing or not already required.
  * Proxy audit results now report received and discarded tool counts.

* **Bug Fixes**
  * Improved rejection handling for missing, duplicate, or invalid tools.
  * Enhanced validation confirms tools are correctly filtered and forwarded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->