### PR TITLE
fix: mirror per-task tools into isolated OpenCode agent

### DIFF
--- a/scripts/provider_worker.py
+++ b/scripts/provider_worker.py
@@ -7,6 +7,7 @@ import os
 import re
 import sys
 from pathlib import Path
+from typing import Mapping
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
@@ -22,6 +23,7 @@ from engine.providers import AntigravityAdapter, OpenCodeOllamaAdapter  # noqa: 
 
 DEFAULT_OPENCODE_AGENT = "factory-worker"
 AGENT_NAME_PATTERN = re.compile(r"^[A-Za-z0-9._/-]+$")
+TOOL_NAME_PATTERN = re.compile(r"^[a-z][a-z0-9_]*$")
 DEFAULT_OPENCODE_AGENT_PROMPT = """You are a bounded App Factory worker.
 Follow the user task literally and make only the requested scoped change.
 Use only tools currently exposed by the runtime. Do not inspect unrelated files.
@@ -42,28 +44,50 @@ def load_request(path: Path) -> ProviderTaskRequest:
     return ProviderTaskRequest.from_mapping(raw)
 
 
-def _prepare_default_opencode_agent(profile: Path, requested_agent: str | None) -> str:
-    """Create the trusted minimal OpenCode agent inside the isolated profile.
+def _validated_agent_name(requested_agent: str) -> str:
+    raw_agent = requested_agent
+    agent = raw_agent.strip()
+    parts = agent.split("/")
+    if (
+        raw_agent != agent
+        or not AGENT_NAME_PATTERN.fullmatch(agent)
+        or agent.startswith(("/", "-"))
+        or agent.endswith(("/", "."))
+        or "//" in agent
+        or any(part in {"", ".", ".."} for part in parts)
+    ):
+        raise ValueError("invalid OpenCode agent identifier")
+    return agent
 
-    Explicit agent IDs remain supported for trusted operator use. Automatic workers
-    use a fixed profile-local agent so they do not inherit OpenCode's broad built-in
-    coding-agent system prompt. Permissions and visible tools remain controlled by
-    the adapter's injected runtime config; this file adds no authority.
+
+def _agent_tool_frontmatter(tool_surface: Mapping[str, bool]) -> str:
+    if not tool_surface:
+        raise ValueError("automatic OpenCode agent requires an explicit tool surface")
+    lines = ["tools:"]
+    for name, enabled in sorted(tool_surface.items()):
+        if not TOOL_NAME_PATTERN.fullmatch(name) or not isinstance(enabled, bool):
+            raise ValueError("invalid automatic OpenCode agent tool surface")
+        lines.append(f"  {name}: {'true' if enabled else 'false'}")
+    return "\n".join(lines)
+
+
+def _prepare_default_opencode_agent(
+    profile: Path,
+    requested_agent: str | None,
+    *,
+    tool_surface: Mapping[str, bool] | None = None,
+) -> str:
+    """Create a trusted request-specific OpenCode agent in the isolated profile.
+
+    Explicit operator agent IDs remain supported after validation. Automatic workers
+    get a fixed profile-local primary agent whose agent-level tool map exactly mirrors
+    the production adapter's per-request tool visibility. The adapter permission map
+    remains the authoritative path/command security boundary.
     """
     if requested_agent:
-        raw_agent = requested_agent
-        agent = raw_agent.strip()
-        parts = agent.split("/")
-        if (
-            raw_agent != agent
-            or not AGENT_NAME_PATTERN.fullmatch(agent)
-            or agent.startswith(("/", "-"))
-            or agent.endswith(("/", "."))
-            or "//" in agent
-            or any(part in {"", ".", ".."} for part in parts)
-        ):
-            raise ValueError("invalid OpenCode agent identifier")
-        return agent
+        return _validated_agent_name(requested_agent)
+    if tool_surface is None:
+        raise ValueError("automatic OpenCode agent requires request-specific tools")
 
     profile = profile.expanduser().resolve()
     agent_dir = profile / "factory-config" / "agents"
@@ -73,6 +97,7 @@ def _prepare_default_opencode_agent(profile: Path, requested_agent: str | None) 
         "---\n"
         "description: Bounded App Factory automatic worker\n"
         "mode: primary\n"
+        f"{_agent_tool_frontmatter(tool_surface)}\n"
         "---\n"
         f"{DEFAULT_OPENCODE_AGENT_PROMPT}",
         encoding="utf-8",
@@ -125,7 +150,9 @@ def parser() -> argparse.ArgumentParser:
     return root
 
 
-def build_adapter(args: argparse.Namespace):
+def build_adapter(
+    args: argparse.Namespace, request: ProviderTaskRequest | None = None
+):
     if args.provider == "antigravity":
         profile = args.profile_home or (
             Path(os.environ["ANTIGRAVITY_PROFILE_HOME"])
@@ -139,28 +166,44 @@ def build_adapter(args: argparse.Namespace):
             agent=args.agent or os.environ.get("ANTIGRAVITY_AGENT") or None,
             profile_home=profile,
         )
+
     profile = args.profile_home or (
         Path(os.environ["OPENCODE_PROFILE_HOME"])
         if os.environ.get("OPENCODE_PROFILE_HOME")
         else None
     )
     requested_agent = args.agent or os.environ.get("OPENCODE_AGENT") or None
-    agent = (
-        _prepare_default_opencode_agent(profile, requested_agent)
-        if profile is not None
-        else requested_agent
-    )
-    return OpenCodeOllamaAdapter(
-        model=args.model or os.environ.get("OPENCODE_OLLAMA_MODEL", ""),
-        binary=args.binary or os.environ.get("OPENCODE_BIN", "opencode"),
-        ollama_binary=args.ollama_binary or os.environ.get("OLLAMA_BIN", "ollama"),
-        agent=agent,
-        ollama_base_url=(
+    common = {
+        "model": args.model or os.environ.get("OPENCODE_OLLAMA_MODEL", ""),
+        "binary": args.binary or os.environ.get("OPENCODE_BIN", "opencode"),
+        "ollama_binary": args.ollama_binary or os.environ.get("OLLAMA_BIN", "ollama"),
+        "ollama_base_url": (
             args.ollama_base_url
             or os.environ.get("OLLAMA_BASE_URL", "http://localhost:11434/v1")
         ),
-        profile_home=profile,
+        "profile_home": profile,
+    }
+    if requested_agent:
+        return OpenCodeOllamaAdapter(
+            **common,
+            agent=(
+                _prepare_default_opencode_agent(profile, requested_agent)
+                if profile is not None
+                else _validated_agent_name(requested_agent)
+            ),
+        )
+    if request is None:
+        return OpenCodeOllamaAdapter(**common, agent=None)
+    if profile is None:
+        raise ValueError("automatic OpenCode execution requires an isolated profile")
+
+    provisional = OpenCodeOllamaAdapter(**common, agent=None)
+    agent = _prepare_default_opencode_agent(
+        profile,
+        None,
+        tool_surface=provisional.tool_config(request),
     )
+    return OpenCodeOllamaAdapter(**common, agent=agent)
 
 
 def main() -> int:
@@ -170,13 +213,16 @@ def main() -> int:
             request = load_request(args.spec)
             emit({"valid": True, "request": request.to_dict()})
             return 0
-        adapter = build_adapter(args)
+
         runner = SubprocessRunner()
         if args.command == "probe":
+            adapter = build_adapter(args)
             health = adapter.probe(runner)
             emit(health.to_dict())
             return 0 if health.status == "healthy" else 2
+
         request = load_request(args.spec)
+        adapter = build_adapter(args, request)
         if args.command == "command":
             emit({
                 "request": request.to_dict(),

--- a/tests/multiagent/test_provider_worker_agent.py
+++ b/tests/multiagent/test_provider_worker_agent.py
@@ -7,16 +7,26 @@ from pathlib import Path
 from scripts.provider_worker import (
     DEFAULT_OPENCODE_AGENT,
     DEFAULT_OPENCODE_AGENT_PROMPT,
+    _agent_tool_frontmatter,
     _prepare_default_opencode_agent,
 )
 
 
 class ProviderWorkerAgentTests(unittest.TestCase):
-    def test_default_agent_is_written_only_inside_isolated_profile(self) -> None:
+    def test_default_agent_mirrors_request_tool_surface_inside_isolated_profile(self) -> None:
         with tempfile.TemporaryDirectory() as raw:
             profile = Path(raw) / "profile"
             profile.mkdir()
-            agent = _prepare_default_opencode_agent(profile, None)
+            agent = _prepare_default_opencode_agent(
+                profile,
+                None,
+                tool_surface={
+                    "write": True,
+                    "read": False,
+                    "edit": False,
+                    "bash": False,
+                },
+            )
             agent_file = (
                 profile
                 / "factory-config"
@@ -28,8 +38,27 @@ class ProviderWorkerAgentTests(unittest.TestCase):
         self.assertEqual(agent, DEFAULT_OPENCODE_AGENT)
         self.assertIn("mode: primary", content)
         self.assertIn(DEFAULT_OPENCODE_AGENT_PROMPT, content)
+        self.assertIn("tools:", content)
+        self.assertIn("  write: true", content)
+        self.assertIn("  read: false", content)
+        self.assertIn("  edit: false", content)
+        self.assertIn("  bash: false", content)
         self.assertNotIn("permission:", content)
-        self.assertNotIn("tools:", content)
+
+    def test_agent_tool_frontmatter_is_deterministic_and_validated(self) -> None:
+        rendered = _agent_tool_frontmatter(
+            {"write": True, "read": False, "bash": False}
+        )
+        self.assertEqual(
+            rendered,
+            "tools:\n  bash: false\n  read: false\n  write: true",
+        )
+        with self.assertRaises(ValueError):
+            _agent_tool_frontmatter({})
+        with self.assertRaises(ValueError):
+            _agent_tool_frontmatter({"../write": True})
+        with self.assertRaises(ValueError):
+            _agent_tool_frontmatter({"write": 1})
 
     def test_explicit_trusted_agent_is_preserved_without_writing_profile_file(self) -> None:
         with tempfile.TemporaryDirectory() as raw:
@@ -39,6 +68,13 @@ class ProviderWorkerAgentTests(unittest.TestCase):
 
             self.assertEqual(agent, "operator-agent")
             self.assertFalse((profile / "factory-config").exists())
+
+    def test_automatic_agent_requires_request_specific_tools(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            profile = Path(raw) / "profile"
+            profile.mkdir()
+            with self.assertRaisesRegex(ValueError, "request-specific tools"):
+                _prepare_default_opencode_agent(profile, None)
 
     def test_invalid_explicit_agent_is_rejected(self) -> None:
         with tempfile.TemporaryDirectory() as raw:


### PR DESCRIPTION
## Summary

Fixes the v7 diagnostic where the loopback shim observed `tools_received=0` even though the production adapter calculated a create-only `write` surface.

Automatic OpenCode workers now generate their profile-local primary agent only after the task request is loaded, and the agent-level `tools` frontmatter exactly mirrors the adapter's per-request visibility map. For create-only tasks this means `write: true` and every other known capability false. The existing adapter permission map remains authoritative for paths and commands.

Probe mode does not create a request agent. Explicit trusted operator agents remain supported after path/name validation. The agent file still lives only in the isolated provider profile and carries no permission expansion.

Adds regressions for deterministic tool frontmatter, validation, explicit-agent behavior, and the request-specific tool requirement. No target merge, production activation, credential access or Codex fallback is introduced.