### PR TITLE
fix: normalize one Ollama tool call to canonical SSE

### DIFF
--- a/.github/workflows/live-opencode-ollama-pilot.yml
+++ b/.github/workflows/live-opencode-ollama-pilot.yml
@@ -10,15 +10,15 @@ permissions:
   contents: write
 
 concurrency:
-  group: ${{ (github.event_name == 'workflow_dispatch' || (github.event_name == 'issue_comment' && github.event.issue.number == 88 && github.event.comment.body == '/run-opencode-v7')) && 'live-opencode-ollama-provider-pilot' || format('live-opencode-ollama-noop-{0}', github.run_id) }}
-  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'issue_comment' && github.event.issue.number == 88 && github.event.comment.body == '/run-opencode-v7') }}
+  group: ${{ (github.event_name == 'workflow_dispatch' || (github.event_name == 'issue_comment' && github.event.issue.number == 91 && github.event.comment.body == '/run-opencode-v8')) && 'live-opencode-ollama-provider-pilot' || format('live-opencode-ollama-noop-{0}', github.run_id) }}
+  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'issue_comment' && github.event.issue.number == 91 && github.event.comment.body == '/run-opencode-v8') }}
 
 jobs:
   live-pilot:
     if: >-
       github.actor == github.repository_owner &&
       ((github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') ||
-       (github.event_name == 'issue_comment' && github.event.issue.number == 88 && github.event.comment.body == '/run-opencode-v7'))
+       (github.event_name == 'issue_comment' && github.event.issue.number == 91 && github.event.comment.body == '/run-opencode-v8'))
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     env:
@@ -54,7 +54,7 @@ jobs:
           echo "${tools_dir}/opencode" >> "${GITHUB_PATH}"
           echo "LD_LIBRARY_PATH=${tools_dir}/ollama/lib" >> "${GITHUB_ENV}"
 
-      - name: Start loopback Ollama and filtered required-tool proxy
+      - name: Start loopback Ollama and canonical tool-call proxy
         shell: bash
         env:
           OLLAMA_CONTEXT_LENGTH: "8192"
@@ -83,7 +83,7 @@ jobs:
               except OSError:
                   time.sleep(1)
           else:
-              raise SystemExit("required-tool proxy did not bind to loopback")
+              raise SystemExit("canonical tool proxy did not bind to loopback")
           PY
           ollama list
           opencode --version
@@ -171,13 +171,15 @@ jobs:
           audit = json.loads(Path(os.environ["RUNNER_TEMP"], "tool-proxy-audit.json").read_text())
           if (
               audit["accepted"] < 1
-              or audit["rewritten"] < 1
               or audit["forwarded"] < 1
               or audit["rejected"] != 0
-              or audit["tools_received"] < 2
-              or audit["tools_discarded"] < 1
+              or audit["tools_received"] < 1
+              or audit["upstream_tool_calls"] != 1
+              or audit["responses_normalized"] != 1
+              or audit["last_status"] != 200
+              or audit["last_reject_reason"] is not None
           ):
-              raise SystemExit(f"unexpected tool proxy audit counters: {audit}")
+              raise SystemExit(f"unexpected canonical tool proxy audit counters: {audit}")
           PY
 
       - name: Confirm remote SHA and run exact-SHA Factory CI

--- a/engine/ollama_tool_proxy.py
+++ b/engine/ollama_tool_proxy.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import urllib.parse
 from typing import Any, Mapping
 
@@ -56,3 +57,95 @@ def rewrite_single_tool_request(
     rewritten["tools"] = [dict(expected_matches[0])]
     rewritten["tool_choice"] = "required"
     return rewritten
+
+
+def canonical_single_tool_sse(
+    payload: Mapping[str, Any], *, expected_tool: str
+) -> bytes:
+    """Validate one complete Ollama/OpenAI tool call and emit one canonical SSE event.
+
+    The function changes only transport shape. It never invents a tool name, tool-call
+    id, or arguments. Object-valued arguments are serialized losslessly as JSON for
+    the OpenAI-compatible streaming schema expected by the client.
+    """
+    if not isinstance(payload, Mapping):
+        raise ValueError("completion response must be a JSON object")
+    completion_id = payload.get("id")
+    model = payload.get("model")
+    if not isinstance(completion_id, str) or not completion_id.strip():
+        raise ValueError("completion response requires an id")
+    if not isinstance(model, str) or not model.strip():
+        raise ValueError("completion response requires a model")
+
+    choices = payload.get("choices")
+    if not isinstance(choices, list) or len(choices) != 1:
+        raise ValueError("completion response requires exactly one choice")
+    choice = choices[0]
+    if not isinstance(choice, Mapping) or choice.get("finish_reason") != "tool_calls":
+        raise ValueError("completion response must finish with tool_calls")
+    message = choice.get("message")
+    if not isinstance(message, Mapping):
+        raise ValueError("completion response requires an assistant message")
+    tool_calls = message.get("tool_calls")
+    if not isinstance(tool_calls, list) or len(tool_calls) != 1:
+        raise ValueError("completion response requires exactly one tool call")
+
+    tool_call = tool_calls[0]
+    if not isinstance(tool_call, Mapping) or tool_call.get("type") != "function":
+        raise ValueError("completion response tool call must be a function")
+    call_id = tool_call.get("id")
+    function = tool_call.get("function")
+    if not isinstance(call_id, str) or not call_id.strip():
+        raise ValueError("completion response tool call requires an id")
+    if not isinstance(function, Mapping) or function.get("name") != expected_tool:
+        raise ValueError("completion response returned an unexpected function tool")
+
+    arguments = function.get("arguments")
+    if isinstance(arguments, Mapping):
+        argument_text = json.dumps(arguments, ensure_ascii=False, separators=(",", ":"))
+    elif isinstance(arguments, str):
+        try:
+            decoded_arguments = json.loads(arguments)
+        except json.JSONDecodeError as error:
+            raise ValueError("completion response tool arguments must be valid JSON") from error
+        if not isinstance(decoded_arguments, Mapping):
+            raise ValueError("completion response tool arguments must be a JSON object")
+        argument_text = arguments
+    else:
+        raise ValueError("completion response tool arguments must be an object or JSON string")
+
+    chunk: dict[str, Any] = {
+        "id": completion_id,
+        "object": "chat.completion.chunk",
+        "model": model,
+        "choices": [
+            {
+                "index": 0,
+                "delta": {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "index": 0,
+                            "id": call_id,
+                            "type": "function",
+                            "function": {
+                                "name": expected_tool,
+                                "arguments": argument_text,
+                            },
+                        }
+                    ],
+                },
+                "finish_reason": "tool_calls",
+            }
+        ],
+    }
+    created = payload.get("created")
+    if isinstance(created, int) and not isinstance(created, bool):
+        chunk["created"] = created
+    usage = payload.get("usage")
+    if isinstance(usage, Mapping):
+        chunk["usage"] = dict(usage)
+
+    event = json.dumps(chunk, ensure_ascii=False, separators=(",", ":"))
+    return f"data: {event}\n\ndata: [DONE]\n\n".encode("utf-8")

--- a/scripts/ollama_tool_proxy.py
+++ b/scripts/ollama_tool_proxy.py
@@ -19,11 +19,13 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from engine.ollama_tool_proxy import (  # noqa: E402
+    canonical_single_tool_sse,
     rewrite_single_tool_request,
     validate_loopback_base_url,
 )
 
 MAX_REQUEST_BYTES = 2 * 1024 * 1024
+MAX_RESPONSE_BYTES = 2 * 1024 * 1024
 SENSITIVE_HEADERS = frozenset({"authorization", "proxy-authorization", "x-api-key"})
 TOOL_CONTRACT_REASON_BY_MESSAGE = {
     "chat request must be a JSON object": "tool_payload",
@@ -40,6 +42,9 @@ REJECT_REASONS = frozenset({
     "content_type",
     "content_length",
     "json_payload",
+    "stream_mode",
+    "response_size",
+    "response_contract",
     *TOOL_CONTRACT_REASON_BY_MESSAGE.values(),
     "tool_contract",
 })
@@ -55,6 +60,8 @@ class ProxyAudit:
     upstream_errors: int = 0
     tools_received: int = 0
     tools_discarded: int = 0
+    upstream_tool_calls: int = 0
+    responses_normalized: int = 0
     last_status: int | None = None
     last_reject_reason: str | None = None
     _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
@@ -71,6 +78,8 @@ class ProxyAudit:
                 "upstream_errors": self.upstream_errors,
                 "tools_received": self.tools_received,
                 "tools_discarded": self.tools_discarded,
+                "upstream_tool_calls": self.upstream_tool_calls,
+                "responses_normalized": self.responses_normalized,
                 "last_status": self.last_status,
                 "last_reject_reason": self.last_reject_reason,
             }
@@ -173,10 +182,12 @@ class RequiredToolProxyHandler(BaseHTTPRequestHandler):
         except (UnicodeDecodeError, json.JSONDecodeError):
             self._reject(400, "json_payload")
             return
-        original_choice = (
-            payload.get("tool_choice", "auto") if isinstance(payload, dict) else None
-        )
-        tools = payload.get("tools") if isinstance(payload, dict) else None
+        if not isinstance(payload, dict) or payload.get("stream") is not True:
+            self._reject(400, "stream_mode")
+            return
+
+        original_choice = payload.get("tool_choice", "auto")
+        tools = payload.get("tools")
         received_tool_count = len(tools) if isinstance(tools, list) else 0
         try:
             rewritten = rewrite_single_tool_request(
@@ -190,9 +201,11 @@ class RequiredToolProxyHandler(BaseHTTPRequestHandler):
             return
 
         retained_tool_count = len(rewritten.get("tools", []))
+        rewritten["stream"] = False
+        rewritten.pop("stream_options", None)
         self.server.audit.mutate(
             accepted=1,
-            rewritten=1 if original_choice != "required" or received_tool_count != 1 else 0,
+            rewritten=1,
             tools_received=received_tool_count,
             tools_discarded=max(received_tool_count - retained_tool_count, 0),
             last_reject_reason=None,
@@ -202,10 +215,7 @@ class RequiredToolProxyHandler(BaseHTTPRequestHandler):
             f"{self.server.upstream_base_url}/chat/completions",
             data=json.dumps(rewritten, separators=(",", ":")).encode("utf-8"),
             method="POST",
-            headers={
-                "Content-Type": "application/json",
-                "Accept": self.headers.get("Accept", "application/json"),
-            },
+            headers={"Content-Type": "application/json", "Accept": "application/json"},
         )
         try:
             response = urllib.request.urlopen(request, timeout=900)
@@ -223,21 +233,47 @@ class RequiredToolProxyHandler(BaseHTTPRequestHandler):
         with response:
             status = int(response.status)
             self.server.audit.mutate(forwarded=1, last_status=status)
-            write_audit(self.server.audit_file, self.server.audit)
-            self.send_response(status)
-            self.send_header(
-                "Content-Type", response.headers.get("Content-Type", "application/json")
+            raw_response = response.read(MAX_RESPONSE_BYTES + 1)
+        if len(raw_response) > MAX_RESPONSE_BYTES:
+            self.server.audit.mutate(
+                upstream_errors=1,
+                last_status=502,
+                last_reject_reason="response_size",
             )
-            self.send_header("Cache-Control", "no-store")
-            self.send_header("Connection", "close")
-            self.end_headers()
-            while True:
-                chunk = response.read(64 * 1024)
-                if not chunk:
-                    break
-                self.wfile.write(chunk)
-                self.wfile.flush()
-            self.close_connection = True
+            write_audit(self.server.audit_file, self.server.audit)
+            self._send_upstream_error(502)
+            return
+        try:
+            completion = json.loads(raw_response)
+            event_stream = canonical_single_tool_sse(
+                completion, expected_tool=self.server.expected_tool
+            )
+        except (UnicodeDecodeError, json.JSONDecodeError, ValueError):
+            self.server.audit.mutate(
+                upstream_errors=1,
+                last_status=502,
+                last_reject_reason="response_contract",
+            )
+            write_audit(self.server.audit_file, self.server.audit)
+            self._send_upstream_error(502)
+            return
+
+        self.server.audit.mutate(
+            upstream_tool_calls=1,
+            responses_normalized=1,
+            last_status=200,
+            last_reject_reason=None,
+        )
+        write_audit(self.server.audit_file, self.server.audit)
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream; charset=utf-8")
+        self.send_header("Cache-Control", "no-store")
+        self.send_header("Content-Length", str(len(event_stream)))
+        self.send_header("Connection", "close")
+        self.end_headers()
+        self.wfile.write(event_stream)
+        self.wfile.flush()
+        self.close_connection = True
 
     def _send_upstream_error(self, status: int) -> None:
         body = b'{"error":"local Ollama upstream failed"}\n'
@@ -252,7 +288,7 @@ class RequiredToolProxyHandler(BaseHTTPRequestHandler):
 
 def parser() -> argparse.ArgumentParser:
     item = argparse.ArgumentParser(
-        description="Fail-closed loopback proxy that filters to one expected OpenAI function tool"
+        description="Fail-closed loopback proxy for one canonical required tool call"
     )
     item.add_argument("--listen-host", default="127.0.0.1")
     item.add_argument("--listen-port", type=int, default=11435)
@@ -275,7 +311,7 @@ def main() -> int:
         )
         print(
             f"required-tool proxy listening on {args.listen_host}:{server.server_port}; "
-            "upstream=loopback; payload logging=disabled",
+            "upstream=loopback; response=canonical-sse; payload logging=disabled",
             flush=True,
         )
         server.serve_forever(poll_interval=0.25)

--- a/tests/multiagent/test_ollama_tool_proxy.py
+++ b/tests/multiagent/test_ollama_tool_proxy.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
+import json
 import unittest
 
-from engine.ollama_tool_proxy import rewrite_single_tool_request, validate_loopback_base_url
+from engine.ollama_tool_proxy import (
+    canonical_single_tool_sse,
+    rewrite_single_tool_request,
+    validate_loopback_base_url,
+)
 
 
 class OllamaToolProxyTests(unittest.TestCase):
@@ -22,6 +27,37 @@ class OllamaToolProxyTests(unittest.TestCase):
             ],
             "tool_choice": "auto",
             "stream": True,
+        }
+
+    def completion_payload(self, *, arguments=None):
+        if arguments is None:
+            arguments = '{"filePath":"pilots/live/result.md","content":"ok\\n"}'
+        return {
+            "id": "chatcmpl-local-1",
+            "object": "chat.completion",
+            "created": 123456,
+            "model": "functiongemma:270m",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": "",
+                        "tool_calls": [
+                            {
+                                "id": "call_write_1",
+                                "type": "function",
+                                "function": {
+                                    "name": "write",
+                                    "arguments": arguments,
+                                },
+                            }
+                        ],
+                    },
+                    "finish_reason": "tool_calls",
+                }
+            ],
+            "usage": {"prompt_tokens": 100, "completion_tokens": 20, "total_tokens": 120},
         }
 
     def test_filters_extra_function_tools_and_forces_expected_tool_required(self) -> None:
@@ -97,6 +133,80 @@ class OllamaToolProxyTests(unittest.TestCase):
         for payload in cases:
             with self.subTest(payload=payload), self.assertRaises(ValueError):
                 rewrite_single_tool_request(payload, expected_tool="write")
+
+    def test_canonical_sse_preserves_one_complete_tool_call(self) -> None:
+        original_arguments = '{"filePath":"pilots/live/result.md","content":"ok\\n"}'
+        wire = canonical_single_tool_sse(
+            self.completion_payload(arguments=original_arguments), expected_tool="write"
+        ).decode("utf-8")
+        events = [line.removeprefix("data: ") for line in wire.splitlines() if line.startswith("data: ")]
+
+        self.assertEqual(events[-1], "[DONE]")
+        chunk = json.loads(events[0])
+        self.assertEqual(chunk["object"], "chat.completion.chunk")
+        self.assertEqual(chunk["created"], 123456)
+        self.assertEqual(chunk["usage"]["total_tokens"], 120)
+        choice = chunk["choices"][0]
+        self.assertEqual(choice["finish_reason"], "tool_calls")
+        call = choice["delta"]["tool_calls"][0]
+        self.assertEqual(call["id"], "call_write_1")
+        self.assertEqual(call["function"]["name"], "write")
+        self.assertEqual(call["function"]["arguments"], original_arguments)
+
+    def test_canonical_sse_serializes_object_arguments_without_changing_values(self) -> None:
+        arguments = {
+            "filePath": "pilots/live/result.md",
+            "content": "olá\n",
+        }
+        wire = canonical_single_tool_sse(
+            self.completion_payload(arguments=arguments), expected_tool="write"
+        ).decode("utf-8")
+        first_event = next(
+            line.removeprefix("data: ") for line in wire.splitlines() if line.startswith("data: ")
+        )
+        call = json.loads(first_event)["choices"][0]["delta"]["tool_calls"][0]
+        self.assertEqual(json.loads(call["function"]["arguments"]), arguments)
+
+    def test_canonical_sse_rejects_invalid_completion_shapes(self) -> None:
+        cases = []
+        cases.append([])
+        no_id = self.completion_payload()
+        no_id["id"] = ""
+        cases.append(no_id)
+        no_model = self.completion_payload()
+        no_model["model"] = None
+        cases.append(no_model)
+        no_choices = self.completion_payload()
+        no_choices["choices"] = []
+        cases.append(no_choices)
+        bad_finish = self.completion_payload()
+        bad_finish["choices"][0]["finish_reason"] = "stop"
+        cases.append(bad_finish)
+        no_message = self.completion_payload()
+        no_message["choices"][0]["message"] = None
+        cases.append(no_message)
+        no_calls = self.completion_payload()
+        no_calls["choices"][0]["message"]["tool_calls"] = []
+        cases.append(no_calls)
+        bad_call_type = self.completion_payload()
+        bad_call_type["choices"][0]["message"]["tool_calls"][0]["type"] = "custom"
+        cases.append(bad_call_type)
+        no_call_id = self.completion_payload()
+        no_call_id["choices"][0]["message"]["tool_calls"][0]["id"] = ""
+        cases.append(no_call_id)
+        wrong_tool = self.completion_payload()
+        wrong_tool["choices"][0]["message"]["tool_calls"][0]["function"]["name"] = "bash"
+        cases.append(wrong_tool)
+        invalid_json_args = self.completion_payload(arguments="{broken")
+        cases.append(invalid_json_args)
+        array_args = self.completion_payload(arguments='["not","object"]')
+        cases.append(array_args)
+        scalar_args = self.completion_payload(arguments=7)
+        cases.append(scalar_args)
+
+        for payload in cases:
+            with self.subTest(payload=payload), self.assertRaises(ValueError):
+                canonical_single_tool_sse(payload, expected_tool="write")
 
     def test_upstream_is_strictly_credential_free_loopback_http(self) -> None:
         self.assertEqual(

--- a/tests/multiagent/test_ollama_tool_proxy_audit.py
+++ b/tests/multiagent/test_ollama_tool_proxy_audit.py
@@ -20,6 +20,9 @@ class OllamaToolProxyAuditTests(unittest.TestCase):
                 "content_type",
                 "content_length",
                 "json_payload",
+                "stream_mode",
+                "response_size",
+                "response_contract",
                 "tool_payload",
                 "tool_messages",
                 "tool_count",
@@ -46,17 +49,24 @@ class OllamaToolProxyAuditTests(unittest.TestCase):
 
         self.assertEqual(snapshot["last_reject_reason"], "tool_count")
         self.assertEqual(snapshot["rejected"], 1)
+        self.assertEqual(snapshot["upstream_tool_calls"], 0)
+        self.assertEqual(snapshot["responses_normalized"], 0)
         self.assertNotIn("prompt", snapshot)
         self.assertNotIn("headers", snapshot)
         self.assertNotIn("arguments", snapshot)
+        self.assertNotIn("response", snapshot)
 
-    def test_acceptance_tracks_only_tool_counts_and_can_clear_last_reason(self) -> None:
+    def test_acceptance_tracks_only_counts_and_response_normalization(self) -> None:
         audit = ProxyAudit(expected_tool="write", rejected=1, last_reject_reason="path")
         audit.mutate(
             accepted=1,
             rewritten=1,
             tools_received=7,
             tools_discarded=6,
+            forwarded=1,
+            upstream_tool_calls=1,
+            responses_normalized=1,
+            last_status=200,
             last_reject_reason=None,
         )
         snapshot = audit.snapshot()
@@ -66,6 +76,10 @@ class OllamaToolProxyAuditTests(unittest.TestCase):
         self.assertEqual(snapshot["rejected"], 1)
         self.assertEqual(snapshot["tools_received"], 7)
         self.assertEqual(snapshot["tools_discarded"], 6)
+        self.assertEqual(snapshot["forwarded"], 1)
+        self.assertEqual(snapshot["upstream_tool_calls"], 1)
+        self.assertEqual(snapshot["responses_normalized"], 1)
+        self.assertEqual(snapshot["last_status"], 200)
         self.assertIsNone(snapshot["last_reject_reason"])
         self.assertNotIn("tool_names", snapshot)
 


### PR DESCRIPTION
## Summary

Implements the immutable v8 contract from issue #91 for the final OpenCode/Ollama streaming compatibility gap proven by v7.

The loopback shim now:
- keeps the request-side authority reduction: retain exactly the expected `write`, discard extra function schemas and require it;
- changes only the forwarded local Ollama request to `stream: false`;
- requires one successful completion choice ending in exactly one expected `write` function call;
- requires a real upstream completion id, tool-call id, model and JSON-object arguments;
- preserves the exact returned tool-call id/name/arguments semantics;
- emits one canonical OpenAI-compatible SSE chunk containing the complete tool call, followed by `[DONE]`;
- rejects textual-only, malformed, multiple, unexpected or oversized responses fail-closed;
- persists only aggregate request/response counters, never prompts, messages, tool arguments, response content or header values.

The v8 live harness still requires a real OpenCode 1.18.23 + Ollama 0.33.1 + FunctionGemma invocation, exact provider-authored one-file evidence, trusted runtime commit/push, remote SHA equality and exact-SHA multiagent CI. No target merge, production activation, protected-path authority or Codex fallback is introduced.

Regression coverage exercises canonical SSE preservation plus every new completion-contract failure path.