### PR TITLE
fix: terminate OpenCode after one verified write result

### DIFF
--- a/.github/workflows/live-opencode-ollama-pilot.yml
+++ b/.github/workflows/live-opencode-ollama-pilot.yml
@@ -10,15 +10,15 @@ permissions:
   contents: write
 
 concurrency:
-  group: ${{ (github.event_name == 'workflow_dispatch' || (github.event_name == 'issue_comment' && github.event.issue.number == 91 && github.event.comment.body == '/run-opencode-v8')) && 'live-opencode-ollama-provider-pilot' || format('live-opencode-ollama-noop-{0}', github.run_id) }}
-  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'issue_comment' && github.event.issue.number == 91 && github.event.comment.body == '/run-opencode-v8') }}
+  group: ${{ (github.event_name == 'workflow_dispatch' || (github.event_name == 'issue_comment' && github.event.issue.number == 93 && github.event.comment.body == '/run-opencode-v9')) && 'live-opencode-ollama-provider-pilot' || format('live-opencode-ollama-noop-{0}', github.run_id) }}
+  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'issue_comment' && github.event.issue.number == 93 && github.event.comment.body == '/run-opencode-v9') }}
 
 jobs:
   live-pilot:
     if: >-
       github.actor == github.repository_owner &&
       ((github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') ||
-       (github.event_name == 'issue_comment' && github.event.issue.number == 91 && github.event.comment.body == '/run-opencode-v8'))
+       (github.event_name == 'issue_comment' && github.event.issue.number == 93 && github.event.comment.body == '/run-opencode-v9'))
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     env:
@@ -54,7 +54,7 @@ jobs:
           echo "${tools_dir}/opencode" >> "${GITHUB_PATH}"
           echo "LD_LIBRARY_PATH=${tools_dir}/ollama/lib" >> "${GITHUB_ENV}"
 
-      - name: Start loopback Ollama and canonical tool-call proxy
+      - name: Start loopback Ollama and single-write terminal proxy
         shell: bash
         env:
           OLLAMA_CONTEXT_LENGTH: "8192"
@@ -83,7 +83,7 @@ jobs:
               except OSError:
                   time.sleep(1)
           else:
-              raise SystemExit("canonical tool proxy did not bind to loopback")
+              raise SystemExit("single-write terminal proxy did not bind to loopback")
           PY
           ollama list
           opencode --version
@@ -170,16 +170,18 @@ jobs:
               raise SystemExit("provider evidence content mismatch")
           audit = json.loads(Path(os.environ["RUNNER_TEMP"], "tool-proxy-audit.json").read_text())
           if (
-              audit["accepted"] < 1
-              or audit["forwarded"] < 1
+              audit["accepted"] != 1
+              or audit["forwarded"] != 1
               or audit["rejected"] != 0
               or audit["tools_received"] < 1
               or audit["upstream_tool_calls"] != 1
               or audit["responses_normalized"] != 1
+              or audit["post_tool_requests"] != 1
+              or audit["post_tool_completions"] != 1
               or audit["last_status"] != 200
               or audit["last_reject_reason"] is not None
           ):
-              raise SystemExit(f"unexpected canonical tool proxy audit counters: {audit}")
+              raise SystemExit(f"unexpected single-write terminal proxy audit counters: {audit}")
           PY
 
       - name: Confirm remote SHA and run exact-SHA Factory CI

--- a/engine/ollama_tool_proxy.py
+++ b/engine/ollama_tool_proxy.py
@@ -149,3 +149,29 @@ def canonical_single_tool_sse(
 
     event = json.dumps(chunk, ensure_ascii=False, separators=(",", ":"))
     return f"data: {event}\n\ndata: [DONE]\n\n".encode("utf-8")
+
+
+def canonical_stop_sse(model: str) -> bytes:
+    """Return a content-free terminal SSE after a verified tool result.
+
+    This acknowledgement carries no task content and no tool call. It exists only to
+    terminate the OpenCode agent loop after the proxy has already verified one real
+    expected tool call and observed the client's corresponding tool-result turn.
+    """
+    clean_model = str(model or "").strip()
+    if not clean_model:
+        raise ValueError("post-tool stop requires a model")
+    chunk = {
+        "id": "chatcmpl-factory-tool-complete",
+        "object": "chat.completion.chunk",
+        "model": clean_model,
+        "choices": [
+            {
+                "index": 0,
+                "delta": {"role": "assistant", "content": ""},
+                "finish_reason": "stop",
+            }
+        ],
+    }
+    event = json.dumps(chunk, ensure_ascii=False, separators=(",", ":"))
+    return f"data: {event}\n\ndata: [DONE]\n\n".encode("utf-8")

--- a/scripts/ollama_tool_proxy.py
+++ b/scripts/ollama_tool_proxy.py
@@ -20,6 +20,7 @@ if str(ROOT) not in sys.path:
 
 from engine.ollama_tool_proxy import (  # noqa: E402
     canonical_single_tool_sse,
+    canonical_stop_sse,
     rewrite_single_tool_request,
     validate_loopback_base_url,
 )
@@ -43,6 +44,7 @@ REJECT_REASONS = frozenset({
     "content_length",
     "json_payload",
     "stream_mode",
+    "tool_sequence",
     "response_size",
     "response_contract",
     *TOOL_CONTRACT_REASON_BY_MESSAGE.values(),
@@ -62,6 +64,8 @@ class ProxyAudit:
     tools_discarded: int = 0
     upstream_tool_calls: int = 0
     responses_normalized: int = 0
+    post_tool_requests: int = 0
+    post_tool_completions: int = 0
     last_status: int | None = None
     last_reject_reason: str | None = None
     _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
@@ -80,6 +84,8 @@ class ProxyAudit:
                 "tools_discarded": self.tools_discarded,
                 "upstream_tool_calls": self.upstream_tool_calls,
                 "responses_normalized": self.responses_normalized,
+                "post_tool_requests": self.post_tool_requests,
+                "post_tool_completions": self.post_tool_completions,
                 "last_status": self.last_status,
                 "last_reject_reason": self.last_reject_reason,
             }
@@ -155,6 +161,17 @@ class RequiredToolProxyHandler(BaseHTTPRequestHandler):
         self.wfile.write(body)
         self.close_connection = True
 
+    def _send_sse(self, event_stream: bytes) -> None:
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream; charset=utf-8")
+        self.send_header("Cache-Control", "no-store")
+        self.send_header("Content-Length", str(len(event_stream)))
+        self.send_header("Connection", "close")
+        self.end_headers()
+        self.wfile.write(event_stream)
+        self.wfile.flush()
+        self.close_connection = True
+
     def do_GET(self) -> None:  # noqa: N802
         self._reject(405, "method")
 
@@ -184,6 +201,33 @@ class RequiredToolProxyHandler(BaseHTTPRequestHandler):
             return
         if not isinstance(payload, dict) or payload.get("stream") is not True:
             self._reject(400, "stream_mode")
+            return
+
+        messages = payload.get("messages")
+        last_message = messages[-1] if isinstance(messages, list) and messages else None
+        if isinstance(last_message, dict) and last_message.get("role") == "tool":
+            before = self.server.audit.snapshot()
+            self.server.audit.mutate(post_tool_requests=1)
+            if (
+                before["responses_normalized"] != 1
+                or before["upstream_tool_calls"] != 1
+                or before["post_tool_completions"] != 0
+                or before["rejected"] != 0
+            ):
+                self._reject(409, "tool_sequence")
+                return
+            try:
+                event_stream = canonical_stop_sse(payload.get("model"))
+            except ValueError:
+                self._reject(400, "tool_sequence")
+                return
+            self.server.audit.mutate(
+                post_tool_completions=1,
+                last_status=200,
+                last_reject_reason=None,
+            )
+            write_audit(self.server.audit_file, self.server.audit)
+            self._send_sse(event_stream)
             return
 
         original_choice = payload.get("tool_choice", "auto")
@@ -265,15 +309,7 @@ class RequiredToolProxyHandler(BaseHTTPRequestHandler):
             last_reject_reason=None,
         )
         write_audit(self.server.audit_file, self.server.audit)
-        self.send_response(200)
-        self.send_header("Content-Type", "text/event-stream; charset=utf-8")
-        self.send_header("Cache-Control", "no-store")
-        self.send_header("Content-Length", str(len(event_stream)))
-        self.send_header("Connection", "close")
-        self.end_headers()
-        self.wfile.write(event_stream)
-        self.wfile.flush()
-        self.close_connection = True
+        self._send_sse(event_stream)
 
     def _send_upstream_error(self, status: int) -> None:
         body = b'{"error":"local Ollama upstream failed"}\n'
@@ -288,7 +324,7 @@ class RequiredToolProxyHandler(BaseHTTPRequestHandler):
 
 def parser() -> argparse.ArgumentParser:
     item = argparse.ArgumentParser(
-        description="Fail-closed loopback proxy for one canonical required tool call"
+        description="Fail-closed loopback proxy for one required tool call and terminal tool result"
     )
     item.add_argument("--listen-host", default="127.0.0.1")
     item.add_argument("--listen-port", type=int, default=11435)
@@ -311,7 +347,7 @@ def main() -> int:
         )
         print(
             f"required-tool proxy listening on {args.listen_host}:{server.server_port}; "
-            "upstream=loopback; response=canonical-sse; payload logging=disabled",
+            "upstream=loopback; response=canonical-sse; post-tool=single-stop; payload logging=disabled",
             flush=True,
         )
         server.serve_forever(poll_interval=0.25)

--- a/tests/multiagent/test_ollama_tool_proxy.py
+++ b/tests/multiagent/test_ollama_tool_proxy.py
@@ -5,6 +5,7 @@ import unittest
 
 from engine.ollama_tool_proxy import (
     canonical_single_tool_sse,
+    canonical_stop_sse,
     rewrite_single_tool_request,
     validate_loopback_base_url,
 )
@@ -139,7 +140,11 @@ class OllamaToolProxyTests(unittest.TestCase):
         wire = canonical_single_tool_sse(
             self.completion_payload(arguments=original_arguments), expected_tool="write"
         ).decode("utf-8")
-        events = [line.removeprefix("data: ") for line in wire.splitlines() if line.startswith("data: ")]
+        events = [
+            line.removeprefix("data: ")
+            for line in wire.splitlines()
+            if line.startswith("data: ")
+        ]
 
         self.assertEqual(events[-1], "[DONE]")
         chunk = json.loads(events[0])
@@ -162,7 +167,9 @@ class OllamaToolProxyTests(unittest.TestCase):
             self.completion_payload(arguments=arguments), expected_tool="write"
         ).decode("utf-8")
         first_event = next(
-            line.removeprefix("data: ") for line in wire.splitlines() if line.startswith("data: ")
+            line.removeprefix("data: ")
+            for line in wire.splitlines()
+            if line.startswith("data: ")
         )
         call = json.loads(first_event)["choices"][0]["delta"]["tool_calls"][0]
         self.assertEqual(json.loads(call["function"]["arguments"]), arguments)
@@ -207,6 +214,28 @@ class OllamaToolProxyTests(unittest.TestCase):
         for payload in cases:
             with self.subTest(payload=payload), self.assertRaises(ValueError):
                 canonical_single_tool_sse(payload, expected_tool="write")
+
+    def test_post_tool_stop_sse_is_content_free_and_terminal(self) -> None:
+        wire = canonical_stop_sse("functiongemma:270m").decode("utf-8")
+        events = [
+            line.removeprefix("data: ")
+            for line in wire.splitlines()
+            if line.startswith("data: ")
+        ]
+
+        self.assertEqual(events[-1], "[DONE]")
+        chunk = json.loads(events[0])
+        self.assertEqual(chunk["id"], "chatcmpl-factory-tool-complete")
+        self.assertEqual(chunk["model"], "functiongemma:270m")
+        choice = chunk["choices"][0]
+        self.assertEqual(choice["finish_reason"], "stop")
+        self.assertEqual(choice["delta"], {"role": "assistant", "content": ""})
+        self.assertNotIn("tool_calls", choice["delta"])
+
+    def test_post_tool_stop_requires_model(self) -> None:
+        for value in ("", "   ", None):
+            with self.subTest(value=value), self.assertRaises(ValueError):
+                canonical_stop_sse(value)  # type: ignore[arg-type]
 
     def test_upstream_is_strictly_credential_free_loopback_http(self) -> None:
         self.assertEqual(

--- a/tests/multiagent/test_ollama_tool_proxy_audit.py
+++ b/tests/multiagent/test_ollama_tool_proxy_audit.py
@@ -21,6 +21,7 @@ class OllamaToolProxyAuditTests(unittest.TestCase):
                 "content_length",
                 "json_payload",
                 "stream_mode",
+                "tool_sequence",
                 "response_size",
                 "response_contract",
                 "tool_payload",
@@ -51,21 +52,30 @@ class OllamaToolProxyAuditTests(unittest.TestCase):
         self.assertEqual(snapshot["rejected"], 1)
         self.assertEqual(snapshot["upstream_tool_calls"], 0)
         self.assertEqual(snapshot["responses_normalized"], 0)
+        self.assertEqual(snapshot["post_tool_requests"], 0)
+        self.assertEqual(snapshot["post_tool_completions"], 0)
         self.assertNotIn("prompt", snapshot)
         self.assertNotIn("headers", snapshot)
         self.assertNotIn("arguments", snapshot)
         self.assertNotIn("response", snapshot)
+        self.assertNotIn("tool_result", snapshot)
 
-    def test_acceptance_tracks_only_counts_and_response_normalization(self) -> None:
-        audit = ProxyAudit(expected_tool="write", rejected=1, last_reject_reason="path")
+    def test_acceptance_tracks_one_tool_then_one_terminal_post_tool_turn(self) -> None:
+        audit = ProxyAudit(expected_tool="write")
         audit.mutate(
             accepted=1,
             rewritten=1,
-            tools_received=7,
-            tools_discarded=6,
+            tools_received=2,
+            tools_discarded=1,
             forwarded=1,
             upstream_tool_calls=1,
             responses_normalized=1,
+            last_status=200,
+            last_reject_reason=None,
+        )
+        audit.mutate(
+            post_tool_requests=1,
+            post_tool_completions=1,
             last_status=200,
             last_reject_reason=None,
         )
@@ -73,12 +83,14 @@ class OllamaToolProxyAuditTests(unittest.TestCase):
 
         self.assertEqual(snapshot["accepted"], 1)
         self.assertEqual(snapshot["rewritten"], 1)
-        self.assertEqual(snapshot["rejected"], 1)
-        self.assertEqual(snapshot["tools_received"], 7)
-        self.assertEqual(snapshot["tools_discarded"], 6)
+        self.assertEqual(snapshot["rejected"], 0)
+        self.assertEqual(snapshot["tools_received"], 2)
+        self.assertEqual(snapshot["tools_discarded"], 1)
         self.assertEqual(snapshot["forwarded"], 1)
         self.assertEqual(snapshot["upstream_tool_calls"], 1)
         self.assertEqual(snapshot["responses_normalized"], 1)
+        self.assertEqual(snapshot["post_tool_requests"], 1)
+        self.assertEqual(snapshot["post_tool_completions"], 1)
         self.assertEqual(snapshot["last_status"], 200)
         self.assertIsNone(snapshot["last_reject_reason"])
         self.assertNotIn("tool_names", snapshot)


### PR DESCRIPTION
## Summary

Implements the immutable v9 contract from issue #93 to terminate the OpenCode agent loop only after a real expected `write` tool call has already been normalized and OpenCode sends the corresponding tool-result turn.

The loopback compatibility shim now:
- preserves the v8 first-turn contract: retain only expected `write`, require it, use real local Ollama inference, validate one exact upstream tool call, and normalize it to canonical SSE;
- recognizes a post-tool request only when the last OpenAI-compatible message has role `tool`;
- emits one content-free terminal SSE `finish_reason: stop` only if the same proxy process has exactly one normalized expected tool call, zero prior post-tool completions, and zero prior rejects;
- never forwards that terminal acknowledgement to the model and never fabricates tool arguments or task content;
- rejects any post-tool sequence before a verified write or any repeated post-tool completion fail-closed.

The trusted provider runtime remains the durable authority: OpenCode still has to execute the real `write`, produce the exact tracked file, pass scope/diff validation, then the runtime alone commits and pushes the worker branch. No provider shell authority, target merge, production activation, protected-path write, permission widening or Codex fallback is introduced.

The v9 live harness requires audit evidence of exactly one model tool call plus exactly one terminal post-tool acknowledgement before remote SHA confirmation and exact-SHA multiagent CI.