### PR TITLE
fix: bound and diagnose OpenCode tool responses

### DIFF
--- a/.github/workflows/live-opencode-ollama-pilot.yml
+++ b/.github/workflows/live-opencode-ollama-pilot.yml
@@ -10,15 +10,15 @@ permissions:
   contents: write
 
 concurrency:
-  group: ${{ (github.event_name == 'workflow_dispatch' || (github.event_name == 'issue_comment' && github.event.issue.number == 93 && github.event.comment.body == '/run-opencode-v9')) && 'live-opencode-ollama-provider-pilot' || format('live-opencode-ollama-noop-{0}', github.run_id) }}
-  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'issue_comment' && github.event.issue.number == 93 && github.event.comment.body == '/run-opencode-v9') }}
+  group: ${{ (github.event_name == 'workflow_dispatch' || (github.event_name == 'issue_comment' && github.event.issue.number == 96 && github.event.comment.body == '/run-opencode-v10')) && 'live-opencode-ollama-provider-pilot' || format('live-opencode-ollama-noop-{0}', github.run_id) }}
+  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'issue_comment' && github.event.issue.number == 96 && github.event.comment.body == '/run-opencode-v10') }}
 
 jobs:
   live-pilot:
     if: >-
       github.actor == github.repository_owner &&
       ((github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') ||
-       (github.event_name == 'issue_comment' && github.event.issue.number == 93 && github.event.comment.body == '/run-opencode-v9'))
+       (github.event_name == 'issue_comment' && github.event.issue.number == 96 && github.event.comment.body == '/run-opencode-v10'))
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     env:
@@ -54,7 +54,7 @@ jobs:
           echo "${tools_dir}/opencode" >> "${GITHUB_PATH}"
           echo "LD_LIBRARY_PATH=${tools_dir}/ollama/lib" >> "${GITHUB_ENV}"
 
-      - name: Start loopback Ollama and single-write terminal proxy
+      - name: Start loopback Ollama and deterministic single-write proxy
         shell: bash
         env:
           OLLAMA_CONTEXT_LENGTH: "8192"
@@ -83,7 +83,7 @@ jobs:
               except OSError:
                   time.sleep(1)
           else:
-              raise SystemExit("single-write terminal proxy did not bind to loopback")
+              raise SystemExit("deterministic single-write proxy did not bind to loopback")
           PY
           ollama list
           opencode --version
@@ -170,7 +170,11 @@ jobs:
               raise SystemExit("provider evidence content mismatch")
           audit = json.loads(Path(os.environ["RUNNER_TEMP"], "tool-proxy-audit.json").read_text())
           if (
-              audit["accepted"] != 1
+              audit["schema_version"] != 2
+              or audit["generation_temperature"] != 0
+              or audit["generation_seed"] != 0
+              or audit["generation_max_tokens"] != 512
+              or audit["accepted"] != 1
               or audit["forwarded"] != 1
               or audit["rejected"] != 0
               or audit["tools_received"] < 1
@@ -180,8 +184,9 @@ jobs:
               or audit["post_tool_completions"] != 1
               or audit["last_status"] != 200
               or audit["last_reject_reason"] is not None
+              or audit["last_response_contract_stage"] is not None
           ):
-              raise SystemExit(f"unexpected single-write terminal proxy audit counters: {audit}")
+              raise SystemExit(f"unexpected deterministic single-write proxy audit counters: {audit}")
           PY
 
       - name: Confirm remote SHA and run exact-SHA Factory CI

--- a/engine/ollama_tool_proxy.py
+++ b/engine/ollama_tool_proxy.py
@@ -4,6 +4,10 @@ import json
 import urllib.parse
 from typing import Any, Mapping
 
+TOOL_GENERATION_TEMPERATURE = 0
+TOOL_GENERATION_SEED = 0
+TOOL_GENERATION_MAX_TOKENS = 512
+
 
 def validate_loopback_base_url(value: str) -> str:
     raw = str(value or "").strip().rstrip("/")
@@ -55,7 +59,17 @@ def rewrite_single_tool_request(
 
     rewritten = dict(payload)
     rewritten["tools"] = [dict(expected_matches[0])]
+    # Ollama's OpenAI-compatible endpoint does not guarantee enforcement of
+    # tool_choice. Keep it as a compatibility hint, but completion is accepted only
+    # after a real structured tool call passes canonical_single_tool_sse().
     rewritten["tool_choice"] = "required"
+    # FunctionGemma can otherwise wander for thousands of tokens on a malformed
+    # tool turn. Make local inference reproducible and tightly bounded without ever
+    # fabricating a tool call or its arguments.
+    rewritten["temperature"] = TOOL_GENERATION_TEMPERATURE
+    rewritten["seed"] = TOOL_GENERATION_SEED
+    rewritten["max_tokens"] = TOOL_GENERATION_MAX_TOKENS
+    rewritten.pop("max_completion_tokens", None)
     return rewritten
 
 

--- a/scripts/ollama_tool_proxy.py
+++ b/scripts/ollama_tool_proxy.py
@@ -19,6 +19,9 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from engine.ollama_tool_proxy import (  # noqa: E402
+    TOOL_GENERATION_MAX_TOKENS,
+    TOOL_GENERATION_SEED,
+    TOOL_GENERATION_TEMPERATURE,
     canonical_single_tool_sse,
     canonical_stop_sse,
     rewrite_single_tool_request,
@@ -36,6 +39,37 @@ TOOL_CONTRACT_REASON_BY_MESSAGE = {
     "required-tool proxy requires exactly one expected function tool": "tool_name",
     "required-tool proxy rejects conflicting tool_choice": "tool_choice",
 }
+RESPONSE_CONTRACT_STAGE_BY_MESSAGE = {
+    "completion response must be a JSON object": "payload",
+    "completion response requires an id": "completion_id",
+    "completion response requires a model": "model",
+    "completion response requires exactly one choice": "choice_count",
+    "completion response must finish with tool_calls": "finish_reason",
+    "completion response requires an assistant message": "assistant_message",
+    "completion response requires exactly one tool call": "tool_call_count",
+    "completion response tool call must be a function": "tool_type",
+    "completion response tool call requires an id": "tool_call_id",
+    "completion response returned an unexpected function tool": "tool_name",
+    "completion response tool arguments must be valid JSON": "arguments",
+    "completion response tool arguments must be a JSON object": "arguments",
+    "completion response tool arguments must be an object or JSON string": "arguments",
+}
+RESPONSE_CONTRACT_STAGES = frozenset({
+    "encoding",
+    "json",
+    "payload",
+    "completion_id",
+    "model",
+    "choice_count",
+    "finish_reason",
+    "assistant_message",
+    "tool_call_count",
+    "tool_type",
+    "tool_call_id",
+    "tool_name",
+    "arguments",
+    "unknown",
+})
 REJECT_REASONS = frozenset({
     "method",
     "path",
@@ -50,6 +84,11 @@ REJECT_REASONS = frozenset({
     *TOOL_CONTRACT_REASON_BY_MESSAGE.values(),
     "tool_contract",
 })
+
+
+def safe_response_contract_stage(error: ValueError) -> str:
+    """Return a bounded diagnostic code without exposing upstream response content."""
+    return RESPONSE_CONTRACT_STAGE_BY_MESSAGE.get(str(error), "unknown")
 
 
 @dataclass
@@ -68,12 +107,13 @@ class ProxyAudit:
     post_tool_completions: int = 0
     last_status: int | None = None
     last_reject_reason: str | None = None
+    last_response_contract_stage: str | None = None
     _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
 
     def snapshot(self) -> dict[str, Any]:
         with self._lock:
             return {
-                "schema_version": 1,
+                "schema_version": 2,
                 "expected_tool": self.expected_tool,
                 "accepted": self.accepted,
                 "rejected": self.rejected,
@@ -88,12 +128,20 @@ class ProxyAudit:
                 "post_tool_completions": self.post_tool_completions,
                 "last_status": self.last_status,
                 "last_reject_reason": self.last_reject_reason,
+                "last_response_contract_stage": self.last_response_contract_stage,
+                "generation_temperature": TOOL_GENERATION_TEMPERATURE,
+                "generation_seed": TOOL_GENERATION_SEED,
+                "generation_max_tokens": TOOL_GENERATION_MAX_TOKENS,
             }
 
     def mutate(self, **updates: Any) -> None:
         with self._lock:
             for name, value in updates.items():
-                if name in {"last_status", "last_reject_reason"}:
+                if name in {
+                    "last_status",
+                    "last_reject_reason",
+                    "last_response_contract_stage",
+                }:
                     setattr(self, name, value)
                 else:
                     setattr(self, name, getattr(self, name) + value)
@@ -150,6 +198,7 @@ class RequiredToolProxyHandler(BaseHTTPRequestHandler):
             rejected=1,
             last_status=status,
             last_reject_reason=reason,
+            last_response_contract_stage=None,
         )
         write_audit(self.server.audit_file, self.server.audit)
         body = b'{"error":"required-tool proxy rejected request"}\n'
@@ -225,12 +274,12 @@ class RequiredToolProxyHandler(BaseHTTPRequestHandler):
                 post_tool_completions=1,
                 last_status=200,
                 last_reject_reason=None,
+                last_response_contract_stage=None,
             )
             write_audit(self.server.audit_file, self.server.audit)
             self._send_sse(event_stream)
             return
 
-        original_choice = payload.get("tool_choice", "auto")
         tools = payload.get("tools")
         received_tool_count = len(tools) if isinstance(tools, list) else 0
         try:
@@ -253,6 +302,7 @@ class RequiredToolProxyHandler(BaseHTTPRequestHandler):
             tools_received=received_tool_count,
             tools_discarded=max(received_tool_count - retained_tool_count, 0),
             last_reject_reason=None,
+            last_response_contract_stage=None,
         )
         write_audit(self.server.audit_file, self.server.audit)
         request = urllib.request.Request(
@@ -264,12 +314,20 @@ class RequiredToolProxyHandler(BaseHTTPRequestHandler):
         try:
             response = urllib.request.urlopen(request, timeout=900)
         except urllib.error.HTTPError as error:
-            self.server.audit.mutate(upstream_errors=1, last_status=error.code)
+            self.server.audit.mutate(
+                upstream_errors=1,
+                last_status=error.code,
+                last_response_contract_stage=None,
+            )
             write_audit(self.server.audit_file, self.server.audit)
             self._send_upstream_error(error.code)
             return
         except (urllib.error.URLError, TimeoutError, OSError):
-            self.server.audit.mutate(upstream_errors=1, last_status=502)
+            self.server.audit.mutate(
+                upstream_errors=1,
+                last_status=502,
+                last_response_contract_stage=None,
+            )
             write_audit(self.server.audit_file, self.server.audit)
             self._send_upstream_error(502)
             return
@@ -283,20 +341,33 @@ class RequiredToolProxyHandler(BaseHTTPRequestHandler):
                 upstream_errors=1,
                 last_status=502,
                 last_reject_reason="response_size",
+                last_response_contract_stage=None,
             )
             write_audit(self.server.audit_file, self.server.audit)
             self._send_upstream_error(502)
             return
         try:
             completion = json.loads(raw_response)
-            event_stream = canonical_single_tool_sse(
-                completion, expected_tool=self.server.expected_tool
-            )
-        except (UnicodeDecodeError, json.JSONDecodeError, ValueError):
+        except UnicodeDecodeError:
+            response_stage = "encoding"
+        except json.JSONDecodeError:
+            response_stage = "json"
+        else:
+            try:
+                event_stream = canonical_single_tool_sse(
+                    completion, expected_tool=self.server.expected_tool
+                )
+            except ValueError as error:
+                response_stage = safe_response_contract_stage(error)
+            else:
+                response_stage = None
+
+        if response_stage is not None:
             self.server.audit.mutate(
                 upstream_errors=1,
                 last_status=502,
                 last_reject_reason="response_contract",
+                last_response_contract_stage=response_stage,
             )
             write_audit(self.server.audit_file, self.server.audit)
             self._send_upstream_error(502)
@@ -307,6 +378,7 @@ class RequiredToolProxyHandler(BaseHTTPRequestHandler):
             responses_normalized=1,
             last_status=200,
             last_reject_reason=None,
+            last_response_contract_stage=None,
         )
         write_audit(self.server.audit_file, self.server.audit)
         self._send_sse(event_stream)
@@ -347,7 +419,8 @@ def main() -> int:
         )
         print(
             f"required-tool proxy listening on {args.listen_host}:{server.server_port}; "
-            "upstream=loopback; response=canonical-sse; post-tool=single-stop; payload logging=disabled",
+            "upstream=loopback; response=canonical-sse; post-tool=single-stop; "
+            f"generation=deterministic/{TOOL_GENERATION_MAX_TOKENS}; payload logging=disabled",
             flush=True,
         )
         server.serve_forever(poll_interval=0.25)

--- a/tests/multiagent/test_ollama_tool_proxy.py
+++ b/tests/multiagent/test_ollama_tool_proxy.py
@@ -4,6 +4,9 @@ import json
 import unittest
 
 from engine.ollama_tool_proxy import (
+    TOOL_GENERATION_MAX_TOKENS,
+    TOOL_GENERATION_SEED,
+    TOOL_GENERATION_TEMPERATURE,
     canonical_single_tool_sse,
     canonical_stop_sse,
     rewrite_single_tool_request,
@@ -89,8 +92,14 @@ class OllamaToolProxyTests(unittest.TestCase):
         self.assertEqual(rewritten["tool_choice"], "required")
         self.assertEqual(len(rewritten["tools"]), 1)
         self.assertEqual(rewritten["tools"][0]["function"]["name"], "write")
+        self.assertEqual(rewritten["temperature"], TOOL_GENERATION_TEMPERATURE)
+        self.assertEqual(rewritten["seed"], TOOL_GENERATION_SEED)
+        self.assertEqual(rewritten["max_tokens"], TOOL_GENERATION_MAX_TOKENS)
         self.assertEqual(len(payload["tools"]), 3)
         self.assertEqual(payload["tool_choice"], "auto")
+        self.assertNotIn("temperature", payload)
+        self.assertNotIn("seed", payload)
+        self.assertNotIn("max_tokens", payload)
 
     def test_rewrites_missing_or_required_choice_without_expanding_authority(self) -> None:
         missing = self.base_payload()
@@ -106,6 +115,26 @@ class OllamaToolProxyTests(unittest.TestCase):
             rewrite_single_tool_request(already, expected_tool="write")["tool_choice"],
             "required",
         )
+
+    def test_overrides_stochastic_or_oversized_generation_controls(self) -> None:
+        payload = self.base_payload()
+        payload.update(
+            {
+                "temperature": 1.7,
+                "seed": 999,
+                "max_tokens": 9000,
+                "max_completion_tokens": 12000,
+            }
+        )
+
+        rewritten = rewrite_single_tool_request(payload, expected_tool="write")
+
+        self.assertEqual(rewritten["temperature"], 0)
+        self.assertEqual(rewritten["seed"], 0)
+        self.assertEqual(rewritten["max_tokens"], 512)
+        self.assertNotIn("max_completion_tokens", rewritten)
+        self.assertEqual(payload["temperature"], 1.7)
+        self.assertEqual(payload["max_completion_tokens"], 12000)
 
     def test_rejects_missing_duplicate_non_function_or_conflicting_expected_tool(self) -> None:
         cases = []

--- a/tests/multiagent/test_ollama_tool_proxy_audit.py
+++ b/tests/multiagent/test_ollama_tool_proxy_audit.py
@@ -5,7 +5,10 @@ import unittest
 from scripts.ollama_tool_proxy import (
     ProxyAudit,
     REJECT_REASONS,
+    RESPONSE_CONTRACT_STAGE_BY_MESSAGE,
+    RESPONSE_CONTRACT_STAGES,
     TOOL_CONTRACT_REASON_BY_MESSAGE,
+    safe_response_contract_stage,
 )
 
 
@@ -48,7 +51,12 @@ class OllamaToolProxyAuditTests(unittest.TestCase):
         audit.mutate(rejected=1, last_status=400, last_reject_reason="tool_count")
         snapshot = audit.snapshot()
 
+        self.assertEqual(snapshot["schema_version"], 2)
         self.assertEqual(snapshot["last_reject_reason"], "tool_count")
+        self.assertIsNone(snapshot["last_response_contract_stage"])
+        self.assertEqual(snapshot["generation_temperature"], 0)
+        self.assertEqual(snapshot["generation_seed"], 0)
+        self.assertEqual(snapshot["generation_max_tokens"], 512)
         self.assertEqual(snapshot["rejected"], 1)
         self.assertEqual(snapshot["upstream_tool_calls"], 0)
         self.assertEqual(snapshot["responses_normalized"], 0)
@@ -59,6 +67,43 @@ class OllamaToolProxyAuditTests(unittest.TestCase):
         self.assertNotIn("arguments", snapshot)
         self.assertNotIn("response", snapshot)
         self.assertNotIn("tool_result", snapshot)
+
+    def test_response_contract_stage_is_bounded_and_sanitized(self) -> None:
+        expected = {
+            "payload",
+            "completion_id",
+            "model",
+            "choice_count",
+            "finish_reason",
+            "assistant_message",
+            "tool_call_count",
+            "tool_type",
+            "tool_call_id",
+            "tool_name",
+            "arguments",
+        }
+        self.assertEqual(set(RESPONSE_CONTRACT_STAGE_BY_MESSAGE.values()), expected)
+        self.assertTrue(expected.issubset(RESPONSE_CONTRACT_STAGES))
+        self.assertIn("encoding", RESPONSE_CONTRACT_STAGES)
+        self.assertIn("json", RESPONSE_CONTRACT_STAGES)
+        self.assertIn("unknown", RESPONSE_CONTRACT_STAGES)
+
+        for message, stage in RESPONSE_CONTRACT_STAGE_BY_MESSAGE.items():
+            with self.subTest(stage=stage):
+                self.assertEqual(safe_response_contract_stage(ValueError(message)), stage)
+
+        secretish = "completion leaked content SECRET-123"
+        self.assertEqual(safe_response_contract_stage(ValueError(secretish)), "unknown")
+        audit = ProxyAudit(expected_tool="write")
+        audit.mutate(
+            upstream_errors=1,
+            last_status=502,
+            last_reject_reason="response_contract",
+            last_response_contract_stage="finish_reason",
+        )
+        snapshot = audit.snapshot()
+        self.assertEqual(snapshot["last_response_contract_stage"], "finish_reason")
+        self.assertNotIn(secretish, str(snapshot))
 
     def test_acceptance_tracks_one_tool_then_one_terminal_post_tool_turn(self) -> None:
         audit = ProxyAudit(expected_tool="write")
@@ -72,12 +117,14 @@ class OllamaToolProxyAuditTests(unittest.TestCase):
             responses_normalized=1,
             last_status=200,
             last_reject_reason=None,
+            last_response_contract_stage=None,
         )
         audit.mutate(
             post_tool_requests=1,
             post_tool_completions=1,
             last_status=200,
             last_reject_reason=None,
+            last_response_contract_stage=None,
         )
         snapshot = audit.snapshot()
 
@@ -93,6 +140,7 @@ class OllamaToolProxyAuditTests(unittest.TestCase):
         self.assertEqual(snapshot["post_tool_completions"], 1)
         self.assertEqual(snapshot["last_status"], 200)
         self.assertIsNone(snapshot["last_reject_reason"])
+        self.assertIsNone(snapshot["last_response_contract_stage"])
         self.assertNotIn("tool_names", snapshot)
 
 


### PR DESCRIPTION
## Summary

Hardens the real OpenCode/Ollama compatibility shim after v9 produced six local Ollama HTTP 200 responses that failed the structured tool-call contract.

- pins the one-tool upstream turn to `temperature=0`, fixed `seed=0`, and `max_tokens=512`;
- preserves `tool_choice=required` only as a compatibility hint; success still requires one real structured upstream `write` call;
- adds a bounded sanitized response-contract stage enum (`finish_reason`, `tool_call_count`, `arguments`, etc.) without persisting response text, prompt, arguments or headers;
- bumps the aggregate proxy audit schema to v2 and records the deterministic generation bounds;
- adds regression coverage for stochastic/oversized input overrides and sanitized diagnostics;
- wires immutable live pilot v10 through issue #96.

No tool call, id, arguments, file content or success is fabricated. Provider shell remains disabled, the trusted runtime remains the only commit/push authority, target merge/production remain forbidden, and Codex remains excluded.