### PR TITLE
fix: bridge OpenCode to native Ollama tool calls

### DIFF
--- a/.github/workflows/live-opencode-ollama-pilot.yml
+++ b/.github/workflows/live-opencode-ollama-pilot.yml
@@ -10,15 +10,15 @@ permissions:
   contents: write
 
 concurrency:
-  group: ${{ (github.event_name == 'workflow_dispatch' || (github.event_name == 'issue_comment' && github.event.issue.number == 96 && github.event.comment.body == '/run-opencode-v10')) && 'live-opencode-ollama-provider-pilot' || format('live-opencode-ollama-noop-{0}', github.run_id) }}
-  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'issue_comment' && github.event.issue.number == 96 && github.event.comment.body == '/run-opencode-v10') }}
+  group: ${{ (github.event_name == 'workflow_dispatch' || (github.event_name == 'issue_comment' && github.event.issue.number == 98 && github.event.comment.body == '/run-opencode-v11')) && 'live-opencode-ollama-provider-pilot' || format('live-opencode-ollama-noop-{0}', github.run_id) }}
+  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'issue_comment' && github.event.issue.number == 98 && github.event.comment.body == '/run-opencode-v11') }}
 
 jobs:
   live-pilot:
     if: >-
       github.actor == github.repository_owner &&
       ((github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') ||
-       (github.event_name == 'issue_comment' && github.event.issue.number == 96 && github.event.comment.body == '/run-opencode-v10'))
+       (github.event_name == 'issue_comment' && github.event.issue.number == 98 && github.event.comment.body == '/run-opencode-v11'))
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     env:
@@ -54,7 +54,7 @@ jobs:
           echo "${tools_dir}/opencode" >> "${GITHUB_PATH}"
           echo "LD_LIBRARY_PATH=${tools_dir}/ollama/lib" >> "${GITHUB_ENV}"
 
-      - name: Start loopback Ollama and deterministic single-write proxy
+      - name: Start loopback Ollama and native single-write bridge
         shell: bash
         env:
           OLLAMA_CONTEXT_LENGTH: "8192"
@@ -70,7 +70,7 @@ jobs:
           nohup python scripts/ollama_tool_proxy.py \
             --listen-host 127.0.0.1 \
             --listen-port 11435 \
-            --upstream http://127.0.0.1:11434/v1 \
+            --upstream http://127.0.0.1:11434 \
             --expected-tool write \
             --audit-file "${RUNNER_TEMP}/tool-proxy-audit.json" \
             > "${RUNNER_TEMP}/tool-proxy.log" 2>&1 &
@@ -83,7 +83,7 @@ jobs:
               except OSError:
                   time.sleep(1)
           else:
-              raise SystemExit("deterministic single-write proxy did not bind to loopback")
+              raise SystemExit("native single-write bridge did not bind to loopback")
           PY
           ollama list
           opencode --version
@@ -170,7 +170,8 @@ jobs:
               raise SystemExit("provider evidence content mismatch")
           audit = json.loads(Path(os.environ["RUNNER_TEMP"], "tool-proxy-audit.json").read_text())
           if (
-              audit["schema_version"] != 2
+              audit["schema_version"] != 3
+              or audit["upstream_protocol"] != "ollama_native_chat"
               or audit["generation_temperature"] != 0
               or audit["generation_seed"] != 0
               or audit["generation_max_tokens"] != 512
@@ -186,7 +187,7 @@ jobs:
               or audit["last_reject_reason"] is not None
               or audit["last_response_contract_stage"] is not None
           ):
-              raise SystemExit(f"unexpected deterministic single-write proxy audit counters: {audit}")
+              raise SystemExit(f"unexpected native single-write bridge audit counters: {audit}")
           PY
 
       - name: Confirm remote SHA and run exact-SHA Factory CI

--- a/engine/ollama_tool_proxy.py
+++ b/engine/ollama_tool_proxy.py
@@ -87,9 +87,7 @@ def native_single_tool_request(
     if not isinstance(model, str) or not model.strip():
         raise ValueError("native chat request requires a model")
 
-    source_messages = filtered.get("messages")
-    if not isinstance(source_messages, list) or not source_messages:
-        raise ValueError("native chat request requires messages")
+    source_messages = filtered["messages"]
     native_messages: list[dict[str, str]] = []
     for message in source_messages:
         if not isinstance(message, Mapping):

--- a/engine/ollama_tool_proxy.py
+++ b/engine/ollama_tool_proxy.py
@@ -28,6 +28,12 @@ def validate_loopback_base_url(value: str) -> str:
     return raw
 
 
+def native_chat_url(value: str) -> str:
+    raw = validate_loopback_base_url(value)
+    parsed = urllib.parse.urlparse(raw)
+    return urllib.parse.urlunparse(parsed._replace(path="/api/chat"))
+
+
 def rewrite_single_tool_request(
     payload: Mapping[str, Any], *, expected_tool: str
 ) -> dict[str, Any]:
@@ -59,13 +65,7 @@ def rewrite_single_tool_request(
 
     rewritten = dict(payload)
     rewritten["tools"] = [dict(expected_matches[0])]
-    # Ollama's OpenAI-compatible endpoint does not guarantee enforcement of
-    # tool_choice. Keep it as a compatibility hint, but completion is accepted only
-    # after a real structured tool call passes canonical_single_tool_sse().
     rewritten["tool_choice"] = "required"
-    # FunctionGemma can otherwise wander for thousands of tokens on a malformed
-    # tool turn. Make local inference reproducible and tightly bounded without ever
-    # fabricating a tool call or its arguments.
     rewritten["temperature"] = TOOL_GENERATION_TEMPERATURE
     rewritten["seed"] = TOOL_GENERATION_SEED
     rewritten["max_tokens"] = TOOL_GENERATION_MAX_TOKENS
@@ -73,15 +73,96 @@ def rewrite_single_tool_request(
     return rewritten
 
 
+def native_single_tool_request(
+    payload: Mapping[str, Any], *, expected_tool: str
+) -> dict[str, Any]:
+    """Translate one validated OpenAI-compatible request to Ollama native chat.
+
+    Only protocol shape and deterministic generation options change. Messages and the
+    retained tool schema come from the real OpenCode request; no task content or tool
+    arguments are invented by the shim.
+    """
+    filtered = rewrite_single_tool_request(payload, expected_tool=expected_tool)
+    model = filtered.get("model")
+    if not isinstance(model, str) or not model.strip():
+        raise ValueError("native chat request requires a model")
+
+    source_messages = filtered.get("messages")
+    if not isinstance(source_messages, list) or not source_messages:
+        raise ValueError("native chat request requires messages")
+    native_messages: list[dict[str, str]] = []
+    for message in source_messages:
+        if not isinstance(message, Mapping):
+            raise ValueError("native chat request messages must be objects")
+        role = message.get("role")
+        content = message.get("content")
+        if role not in {"system", "user", "assistant"}:
+            raise ValueError("native chat request contains an unsupported message role")
+        if not isinstance(content, str):
+            raise ValueError("native chat request message content must be text")
+        native_messages.append({"role": role, "content": content})
+
+    return {
+        "model": model,
+        "messages": native_messages,
+        "tools": filtered["tools"],
+        "stream": False,
+        "options": {
+            "temperature": TOOL_GENERATION_TEMPERATURE,
+            "seed": TOOL_GENERATION_SEED,
+            "num_predict": TOOL_GENERATION_MAX_TOKENS,
+        },
+    }
+
+
+def _tool_sse(
+    *,
+    model: str,
+    completion_id: str,
+    call_id: str,
+    expected_tool: str,
+    argument_text: str,
+    usage: Mapping[str, Any] | None = None,
+    created: int | None = None,
+) -> bytes:
+    chunk: dict[str, Any] = {
+        "id": completion_id,
+        "object": "chat.completion.chunk",
+        "model": model,
+        "choices": [
+            {
+                "index": 0,
+                "delta": {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "index": 0,
+                            "id": call_id,
+                            "type": "function",
+                            "function": {
+                                "name": expected_tool,
+                                "arguments": argument_text,
+                            },
+                        }
+                    ],
+                },
+                "finish_reason": "tool_calls",
+            }
+        ],
+    }
+    if created is not None:
+        chunk["created"] = created
+    if usage:
+        chunk["usage"] = dict(usage)
+    event = json.dumps(chunk, ensure_ascii=False, separators=(",", ":"))
+    return f"data: {event}\n\ndata: [DONE]\n\n".encode("utf-8")
+
+
 def canonical_single_tool_sse(
     payload: Mapping[str, Any], *, expected_tool: str
 ) -> bytes:
-    """Validate one complete Ollama/OpenAI tool call and emit one canonical SSE event.
-
-    The function changes only transport shape. It never invents a tool name, tool-call
-    id, or arguments. Object-valued arguments are serialized losslessly as JSON for
-    the OpenAI-compatible streaming schema expected by the client.
-    """
+    """Validate one complete OpenAI-shaped tool call and emit canonical SSE."""
     if not isinstance(payload, Mapping):
         raise ValueError("completion response must be a JSON object")
     completion_id = payload.get("id")
@@ -128,50 +209,73 @@ def canonical_single_tool_sse(
     else:
         raise ValueError("completion response tool arguments must be an object or JSON string")
 
-    chunk: dict[str, Any] = {
-        "id": completion_id,
-        "object": "chat.completion.chunk",
-        "model": model,
-        "choices": [
-            {
-                "index": 0,
-                "delta": {
-                    "role": "assistant",
-                    "content": "",
-                    "tool_calls": [
-                        {
-                            "index": 0,
-                            "id": call_id,
-                            "type": "function",
-                            "function": {
-                                "name": expected_tool,
-                                "arguments": argument_text,
-                            },
-                        }
-                    ],
-                },
-                "finish_reason": "tool_calls",
-            }
-        ],
-    }
     created = payload.get("created")
-    if isinstance(created, int) and not isinstance(created, bool):
-        chunk["created"] = created
+    safe_created = created if isinstance(created, int) and not isinstance(created, bool) else None
     usage = payload.get("usage")
-    if isinstance(usage, Mapping):
-        chunk["usage"] = dict(usage)
+    safe_usage = usage if isinstance(usage, Mapping) else None
+    return _tool_sse(
+        model=model,
+        completion_id=completion_id,
+        call_id=call_id,
+        expected_tool=expected_tool,
+        argument_text=argument_text,
+        usage=safe_usage,
+        created=safe_created,
+    )
 
-    event = json.dumps(chunk, ensure_ascii=False, separators=(",", ":"))
-    return f"data: {event}\n\ndata: [DONE]\n\n".encode("utf-8")
+
+def canonical_native_tool_sse(
+    payload: Mapping[str, Any], *, expected_tool: str
+) -> bytes:
+    """Validate one real native Ollama tool call and translate only transport metadata."""
+    if not isinstance(payload, Mapping):
+        raise ValueError("native response must be a JSON object")
+    model = payload.get("model")
+    if not isinstance(model, str) or not model.strip():
+        raise ValueError("native response requires a model")
+    if payload.get("done") is not True:
+        raise ValueError("native response must be complete")
+    message = payload.get("message")
+    if not isinstance(message, Mapping):
+        raise ValueError("native response requires an assistant message")
+    if message.get("role") != "assistant":
+        raise ValueError("native response message role must be assistant")
+    tool_calls = message.get("tool_calls")
+    if not isinstance(tool_calls, list) or len(tool_calls) != 1:
+        raise ValueError("native response requires exactly one tool call")
+    tool_call = tool_calls[0]
+    if not isinstance(tool_call, Mapping):
+        raise ValueError("native response tool call must be an object")
+    function = tool_call.get("function")
+    if not isinstance(function, Mapping) or function.get("name") != expected_tool:
+        raise ValueError("native response returned an unexpected function tool")
+    arguments = function.get("arguments")
+    if not isinstance(arguments, Mapping):
+        raise ValueError("native response tool arguments must be an object")
+    argument_text = json.dumps(arguments, ensure_ascii=False, separators=(",", ":"))
+
+    prompt_tokens = payload.get("prompt_eval_count")
+    completion_tokens = payload.get("eval_count")
+    usage: dict[str, int] = {}
+    if isinstance(prompt_tokens, int) and not isinstance(prompt_tokens, bool):
+        usage["prompt_tokens"] = prompt_tokens
+    if isinstance(completion_tokens, int) and not isinstance(completion_tokens, bool):
+        usage["completion_tokens"] = completion_tokens
+    if "prompt_tokens" in usage and "completion_tokens" in usage:
+        usage["total_tokens"] = usage["prompt_tokens"] + usage["completion_tokens"]
+
+    return _tool_sse(
+        model=model,
+        completion_id="chatcmpl-factory-native-tool",
+        call_id="call_factory_native_tool_0",
+        expected_tool=expected_tool,
+        argument_text=argument_text,
+        usage=usage or None,
+    )
 
 
 def canonical_stop_sse(model: str) -> bytes:
-    """Return a content-free terminal SSE after a verified tool result.
-
-    This acknowledgement carries no task content and no tool call. It exists only to
-    terminate the OpenCode agent loop after the proxy has already verified one real
-    expected tool call and observed the client's corresponding tool-result turn.
-    """
+    """Return a content-free terminal SSE after a verified tool result."""
     clean_model = str(model or "").strip()
     if not clean_model:
         raise ValueError("post-tool stop requires a model")

--- a/scripts/ollama_tool_proxy.py
+++ b/scripts/ollama_tool_proxy.py
@@ -22,9 +22,10 @@ from engine.ollama_tool_proxy import (  # noqa: E402
     TOOL_GENERATION_MAX_TOKENS,
     TOOL_GENERATION_SEED,
     TOOL_GENERATION_TEMPERATURE,
-    canonical_single_tool_sse,
+    canonical_native_tool_sse,
     canonical_stop_sse,
-    rewrite_single_tool_request,
+    native_chat_url,
+    native_single_tool_request,
     validate_loopback_base_url,
 )
 
@@ -38,34 +39,33 @@ TOOL_CONTRACT_REASON_BY_MESSAGE = {
     "required-tool proxy accepts only function tools": "tool_type",
     "required-tool proxy requires exactly one expected function tool": "tool_name",
     "required-tool proxy rejects conflicting tool_choice": "tool_choice",
+    "native chat request requires a model": "tool_model",
+    "native chat request requires messages": "tool_messages",
+    "native chat request messages must be objects": "tool_messages",
+    "native chat request contains an unsupported message role": "tool_messages",
+    "native chat request message content must be text": "tool_messages",
 }
 RESPONSE_CONTRACT_STAGE_BY_MESSAGE = {
-    "completion response must be a JSON object": "payload",
-    "completion response requires an id": "completion_id",
-    "completion response requires a model": "model",
-    "completion response requires exactly one choice": "choice_count",
-    "completion response must finish with tool_calls": "finish_reason",
-    "completion response requires an assistant message": "assistant_message",
-    "completion response requires exactly one tool call": "tool_call_count",
-    "completion response tool call must be a function": "tool_type",
-    "completion response tool call requires an id": "tool_call_id",
-    "completion response returned an unexpected function tool": "tool_name",
-    "completion response tool arguments must be valid JSON": "arguments",
-    "completion response tool arguments must be a JSON object": "arguments",
-    "completion response tool arguments must be an object or JSON string": "arguments",
+    "native response must be a JSON object": "payload",
+    "native response requires a model": "model",
+    "native response must be complete": "done",
+    "native response requires an assistant message": "assistant_message",
+    "native response message role must be assistant": "assistant_role",
+    "native response requires exactly one tool call": "tool_call_count",
+    "native response tool call must be an object": "tool_type",
+    "native response returned an unexpected function tool": "tool_name",
+    "native response tool arguments must be an object": "arguments",
 }
 RESPONSE_CONTRACT_STAGES = frozenset({
     "encoding",
     "json",
     "payload",
-    "completion_id",
     "model",
-    "choice_count",
-    "finish_reason",
+    "done",
     "assistant_message",
+    "assistant_role",
     "tool_call_count",
     "tool_type",
-    "tool_call_id",
     "tool_name",
     "arguments",
     "unknown",
@@ -113,8 +113,9 @@ class ProxyAudit:
     def snapshot(self) -> dict[str, Any]:
         with self._lock:
             return {
-                "schema_version": 2,
+                "schema_version": 3,
                 "expected_tool": self.expected_tool,
+                "upstream_protocol": "ollama_native_chat",
                 "accepted": self.accepted,
                 "rejected": self.rejected,
                 "rewritten": self.rewritten,
@@ -175,6 +176,7 @@ class RequiredToolProxyServer(ThreadingHTTPServer):
         if host not in {"127.0.0.1", "localhost", "::1"}:
             raise ValueError("tool proxy must bind to loopback")
         self.upstream_base_url = validate_loopback_base_url(upstream_base_url)
+        self.upstream_native_chat_url = native_chat_url(self.upstream_base_url)
         self.expected_tool = expected_tool
         if not expected_tool or any(char.isspace() for char in expected_tool):
             raise ValueError("expected tool name is invalid")
@@ -283,7 +285,7 @@ class RequiredToolProxyHandler(BaseHTTPRequestHandler):
         tools = payload.get("tools")
         received_tool_count = len(tools) if isinstance(tools, list) else 0
         try:
-            rewritten = rewrite_single_tool_request(
+            native_request = native_single_tool_request(
                 payload, expected_tool=self.server.expected_tool
             )
         except ValueError as error:
@@ -293,9 +295,7 @@ class RequiredToolProxyHandler(BaseHTTPRequestHandler):
             )
             return
 
-        retained_tool_count = len(rewritten.get("tools", []))
-        rewritten["stream"] = False
-        rewritten.pop("stream_options", None)
+        retained_tool_count = len(native_request.get("tools", []))
         self.server.audit.mutate(
             accepted=1,
             rewritten=1,
@@ -306,8 +306,8 @@ class RequiredToolProxyHandler(BaseHTTPRequestHandler):
         )
         write_audit(self.server.audit_file, self.server.audit)
         request = urllib.request.Request(
-            f"{self.server.upstream_base_url}/chat/completions",
-            data=json.dumps(rewritten, separators=(",", ":")).encode("utf-8"),
+            self.server.upstream_native_chat_url,
+            data=json.dumps(native_request, separators=(",", ":")).encode("utf-8"),
             method="POST",
             headers={"Content-Type": "application/json", "Accept": "application/json"},
         )
@@ -354,7 +354,7 @@ class RequiredToolProxyHandler(BaseHTTPRequestHandler):
             response_stage = "json"
         else:
             try:
-                event_stream = canonical_single_tool_sse(
+                event_stream = canonical_native_tool_sse(
                     completion, expected_tool=self.server.expected_tool
                 )
             except ValueError as error:
@@ -396,11 +396,11 @@ class RequiredToolProxyHandler(BaseHTTPRequestHandler):
 
 def parser() -> argparse.ArgumentParser:
     item = argparse.ArgumentParser(
-        description="Fail-closed loopback proxy for one required tool call and terminal tool result"
+        description="Fail-closed loopback bridge for one native Ollama tool call and terminal result"
     )
     item.add_argument("--listen-host", default="127.0.0.1")
     item.add_argument("--listen-port", type=int, default=11435)
-    item.add_argument("--upstream", default="http://127.0.0.1:11434/v1")
+    item.add_argument("--upstream", default="http://127.0.0.1:11434")
     item.add_argument("--expected-tool", required=True)
     item.add_argument("--audit-file", type=Path)
     return item
@@ -419,7 +419,7 @@ def main() -> int:
         )
         print(
             f"required-tool proxy listening on {args.listen_host}:{server.server_port}; "
-            "upstream=loopback; response=canonical-sse; post-tool=single-stop; "
+            "upstream=ollama-native-chat/loopback; response=canonical-sse; post-tool=single-stop; "
             f"generation=deterministic/{TOOL_GENERATION_MAX_TOKENS}; payload logging=disabled",
             flush=True,
         )

--- a/tests/multiagent/test_ollama_tool_proxy.py
+++ b/tests/multiagent/test_ollama_tool_proxy.py
@@ -7,8 +7,11 @@ from engine.ollama_tool_proxy import (
     TOOL_GENERATION_MAX_TOKENS,
     TOOL_GENERATION_SEED,
     TOOL_GENERATION_TEMPERATURE,
+    canonical_native_tool_sse,
     canonical_single_tool_sse,
     canonical_stop_sse,
+    native_chat_url,
+    native_single_tool_request,
     rewrite_single_tool_request,
     validate_loopback_base_url,
 )
@@ -25,7 +28,14 @@ class OllamaToolProxyTests(unittest.TestCase):
                     "function": {
                         "name": "write",
                         "description": "Write a file",
-                        "parameters": {"type": "object"},
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "filePath": {"type": "string"},
+                                "content": {"type": "string"},
+                            },
+                            "required": ["filePath", "content"],
+                        },
                     },
                 }
             ],
@@ -62,6 +72,33 @@ class OllamaToolProxyTests(unittest.TestCase):
                 }
             ],
             "usage": {"prompt_tokens": 100, "completion_tokens": 20, "total_tokens": 120},
+        }
+
+    def native_completion_payload(self, *, arguments=None):
+        if arguments is None:
+            arguments = {
+                "filePath": "pilots/live/result.md",
+                "content": "ok\n",
+            }
+        return {
+            "model": "functiongemma:270m",
+            "created_at": "2026-08-27T22:00:00Z",
+            "message": {
+                "role": "assistant",
+                "content": "plain text must never be authoritative",
+                "tool_calls": [
+                    {
+                        "function": {
+                            "name": "write",
+                            "arguments": arguments,
+                        }
+                    }
+                ],
+            },
+            "done": True,
+            "done_reason": "stop",
+            "prompt_eval_count": 100,
+            "eval_count": 20,
         }
 
     def test_filters_extra_function_tools_and_forces_expected_tool_required(self) -> None:
@@ -163,6 +200,142 @@ class OllamaToolProxyTests(unittest.TestCase):
         for payload in cases:
             with self.subTest(payload=payload), self.assertRaises(ValueError):
                 rewrite_single_tool_request(payload, expected_tool="write")
+
+    def test_native_chat_url_is_derived_only_from_valid_loopback_base(self) -> None:
+        self.assertEqual(
+            native_chat_url("http://127.0.0.1:11434"),
+            "http://127.0.0.1:11434/api/chat",
+        )
+        self.assertEqual(
+            native_chat_url("http://localhost:11434/v1/"),
+            "http://localhost:11434/api/chat",
+        )
+        with self.assertRaises(ValueError):
+            native_chat_url("https://ollama.example.com/v1")
+
+    def test_native_request_preserves_real_messages_and_only_expected_tool(self) -> None:
+        payload = self.base_payload()
+        payload["messages"] = [
+            {"role": "system", "content": "system guidance"},
+            {"role": "user", "content": "create the file"},
+            {"role": "assistant", "content": ""},
+        ]
+        payload["tools"].append(
+            {
+                "type": "function",
+                "function": {
+                    "name": "read",
+                    "description": "Read a file",
+                    "parameters": {"type": "object"},
+                },
+            }
+        )
+
+        native = native_single_tool_request(payload, expected_tool="write")
+
+        self.assertEqual(native["model"], "functiongemma:270m")
+        self.assertEqual(native["messages"], payload["messages"])
+        self.assertEqual(native["tools"], [payload["tools"][0]])
+        self.assertFalse(native["stream"])
+        self.assertEqual(
+            native["options"],
+            {"temperature": 0, "seed": 0, "num_predict": 512},
+        )
+        self.assertNotIn("tool_choice", native)
+        self.assertNotIn("max_tokens", native)
+        self.assertEqual(payload["tool_choice"], "auto")
+
+    def test_native_request_rejects_invalid_model_or_message_shape(self) -> None:
+        missing_model = self.base_payload()
+        missing_model["model"] = ""
+        invalid_object = self.base_payload()
+        invalid_object["messages"] = ["not-an-object"]
+        invalid_role = self.base_payload()
+        invalid_role["messages"] = [{"role": "tool", "content": "result"}]
+        invalid_content = self.base_payload()
+        invalid_content["messages"] = [{"role": "user", "content": ["not", "text"]}]
+
+        for payload in (missing_model, invalid_object, invalid_role, invalid_content):
+            with self.subTest(payload=payload), self.assertRaises(ValueError):
+                native_single_tool_request(payload, expected_tool="write")
+
+    def test_canonical_native_tool_sse_uses_structured_call_not_text_or_done_reason(self) -> None:
+        payload = self.native_completion_payload()
+
+        wire = canonical_native_tool_sse(payload, expected_tool="write").decode("utf-8")
+        first_event = next(
+            line.removeprefix("data: ")
+            for line in wire.splitlines()
+            if line.startswith("data: ")
+        )
+        chunk = json.loads(first_event)
+        choice = chunk["choices"][0]
+        call = choice["delta"]["tool_calls"][0]
+
+        self.assertEqual(choice["finish_reason"], "tool_calls")
+        self.assertEqual(call["id"], "call_factory_native_tool_0")
+        self.assertEqual(call["function"]["name"], "write")
+        self.assertEqual(
+            json.loads(call["function"]["arguments"]),
+            payload["message"]["tool_calls"][0]["function"]["arguments"],
+        )
+        self.assertEqual(chunk["usage"], {
+            "prompt_tokens": 100,
+            "completion_tokens": 20,
+            "total_tokens": 120,
+        })
+        self.assertNotIn(payload["message"]["content"], wire)
+        self.assertEqual(payload["done_reason"], "stop")
+
+    def test_canonical_native_tool_sse_allows_missing_token_counters(self) -> None:
+        payload = self.native_completion_payload()
+        payload.pop("prompt_eval_count")
+        payload.pop("eval_count")
+
+        wire = canonical_native_tool_sse(payload, expected_tool="write").decode("utf-8")
+        first_event = next(
+            line.removeprefix("data: ")
+            for line in wire.splitlines()
+            if line.startswith("data: ")
+        )
+        self.assertNotIn("usage", json.loads(first_event))
+
+    def test_canonical_native_tool_sse_rejects_text_only_or_invalid_structured_calls(self) -> None:
+        cases = []
+        cases.append([])
+        missing_model = self.native_completion_payload()
+        missing_model["model"] = ""
+        cases.append(missing_model)
+        incomplete = self.native_completion_payload()
+        incomplete["done"] = False
+        cases.append(incomplete)
+        no_message = self.native_completion_payload()
+        no_message["message"] = None
+        cases.append(no_message)
+        wrong_role = self.native_completion_payload()
+        wrong_role["message"]["role"] = "user"
+        cases.append(wrong_role)
+        text_only = self.native_completion_payload()
+        text_only["message"].pop("tool_calls")
+        cases.append(text_only)
+        multiple = self.native_completion_payload()
+        multiple["message"]["tool_calls"] *= 2
+        cases.append(multiple)
+        bad_call = self.native_completion_payload()
+        bad_call["message"]["tool_calls"] = ["not-an-object"]
+        cases.append(bad_call)
+        wrong_tool = self.native_completion_payload()
+        wrong_tool["message"]["tool_calls"][0]["function"]["name"] = "bash"
+        cases.append(wrong_tool)
+        no_function = self.native_completion_payload()
+        no_function["message"]["tool_calls"][0]["function"] = None
+        cases.append(no_function)
+        string_args = self.native_completion_payload(arguments='{"filePath":"x"}')
+        cases.append(string_args)
+
+        for payload in cases:
+            with self.subTest(payload=payload), self.assertRaises(ValueError):
+                canonical_native_tool_sse(payload, expected_tool="write")
 
     def test_canonical_sse_preserves_one_complete_tool_call(self) -> None:
         original_arguments = '{"filePath":"pilots/live/result.md","content":"ok\\n"}'

--- a/tests/multiagent/test_ollama_tool_proxy_audit.py
+++ b/tests/multiagent/test_ollama_tool_proxy_audit.py
@@ -33,6 +33,7 @@ class OllamaToolProxyAuditTests(unittest.TestCase):
                 "tool_type",
                 "tool_name",
                 "tool_choice",
+                "tool_model",
                 "tool_contract",
             },
         )
@@ -45,13 +46,15 @@ class OllamaToolProxyAuditTests(unittest.TestCase):
                 "tool_type",
                 "tool_name",
                 "tool_choice",
+                "tool_model",
             },
         )
         audit = ProxyAudit(expected_tool="write")
         audit.mutate(rejected=1, last_status=400, last_reject_reason="tool_count")
         snapshot = audit.snapshot()
 
-        self.assertEqual(snapshot["schema_version"], 2)
+        self.assertEqual(snapshot["schema_version"], 3)
+        self.assertEqual(snapshot["upstream_protocol"], "ollama_native_chat")
         self.assertEqual(snapshot["last_reject_reason"], "tool_count")
         self.assertIsNone(snapshot["last_response_contract_stage"])
         self.assertEqual(snapshot["generation_temperature"], 0)
@@ -67,18 +70,17 @@ class OllamaToolProxyAuditTests(unittest.TestCase):
         self.assertNotIn("arguments", snapshot)
         self.assertNotIn("response", snapshot)
         self.assertNotIn("tool_result", snapshot)
+        self.assertNotIn("messages", snapshot)
 
     def test_response_contract_stage_is_bounded_and_sanitized(self) -> None:
         expected = {
             "payload",
-            "completion_id",
             "model",
-            "choice_count",
-            "finish_reason",
+            "done",
             "assistant_message",
+            "assistant_role",
             "tool_call_count",
             "tool_type",
-            "tool_call_id",
             "tool_name",
             "arguments",
         }
@@ -92,20 +94,20 @@ class OllamaToolProxyAuditTests(unittest.TestCase):
             with self.subTest(stage=stage):
                 self.assertEqual(safe_response_contract_stage(ValueError(message)), stage)
 
-        secretish = "completion leaked content SECRET-123"
+        secretish = "native response leaked content SECRET-123"
         self.assertEqual(safe_response_contract_stage(ValueError(secretish)), "unknown")
         audit = ProxyAudit(expected_tool="write")
         audit.mutate(
             upstream_errors=1,
             last_status=502,
             last_reject_reason="response_contract",
-            last_response_contract_stage="finish_reason",
+            last_response_contract_stage="tool_call_count",
         )
         snapshot = audit.snapshot()
-        self.assertEqual(snapshot["last_response_contract_stage"], "finish_reason")
+        self.assertEqual(snapshot["last_response_contract_stage"], "tool_call_count")
         self.assertNotIn(secretish, str(snapshot))
 
-    def test_acceptance_tracks_one_tool_then_one_terminal_post_tool_turn(self) -> None:
+    def test_acceptance_tracks_one_native_tool_then_one_terminal_post_tool_turn(self) -> None:
         audit = ProxyAudit(expected_tool="write")
         audit.mutate(
             accepted=1,
@@ -128,6 +130,8 @@ class OllamaToolProxyAuditTests(unittest.TestCase):
         )
         snapshot = audit.snapshot()
 
+        self.assertEqual(snapshot["schema_version"], 3)
+        self.assertEqual(snapshot["upstream_protocol"], "ollama_native_chat")
         self.assertEqual(snapshot["accepted"], 1)
         self.assertEqual(snapshot["rewritten"], 1)
         self.assertEqual(snapshot["rejected"], 0)


### PR DESCRIPTION
## Summary

Moves only the loopback compatibility shim's upstream inference from Ollama's OpenAI-compatible `/v1/chat/completions` path to native `POST /api/chat`, after v10 proved that the OpenAI-compatible path repeatedly returned HTTP 200 but no acceptable structured tool-call finish.

### Security/semantic boundary

- OpenCode remains the real client and continues to receive OpenAI-compatible SSE from the loopback shim.
- Ollama native `/api/chat` receives the real OpenCode messages and exactly one retained `write` tool schema.
- Native generation is deterministic and bounded (`temperature=0`, `seed=0`, `num_predict=512`).
- Success requires exactly one real native `message.tool_calls[].function` named `write` with object arguments.
- Plain model text is never parsed or converted into a tool call.
- The shim synthesizes only transport identifiers required by the OpenAI-compatible client; tool name and arguments come unchanged from the native structured response.
- The post-tool turn remains a single content-free terminal SSE after OpenCode reports the verified tool result; no second inference occurs.
- Provider shell remains disabled; trusted runtime remains the only commit/push authority; target merge, production, protected paths, permission widening and Codex remain forbidden.

### Validation

Adds regression coverage for native URL derivation, request translation, deterministic native options, structured tool-call conversion, textual-only/multiple/wrong-tool/invalid-argument rejection, sanitized audit schema v3, and immutable live pilot v11 via issue #98.