### PR TITLE
test: run native Qwen3 0.6B live pilot v12

### DIFF
--- a/.github/workflows/live-opencode-ollama-pilot.yml
+++ b/.github/workflows/live-opencode-ollama-pilot.yml
@@ -10,15 +10,15 @@ permissions:
   contents: write
 
 concurrency:
-  group: ${{ (github.event_name == 'workflow_dispatch' || (github.event_name == 'issue_comment' && github.event.issue.number == 98 && github.event.comment.body == '/run-opencode-v11')) && 'live-opencode-ollama-provider-pilot' || format('live-opencode-ollama-noop-{0}', github.run_id) }}
-  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'issue_comment' && github.event.issue.number == 98 && github.event.comment.body == '/run-opencode-v11') }}
+  group: ${{ (github.event_name == 'workflow_dispatch' || (github.event_name == 'issue_comment' && github.event.issue.number == 100 && github.event.comment.body == '/run-opencode-v12')) && 'live-opencode-ollama-provider-pilot' || format('live-opencode-ollama-noop-{0}', github.run_id) }}
+  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'issue_comment' && github.event.issue.number == 100 && github.event.comment.body == '/run-opencode-v12') }}
 
 jobs:
   live-pilot:
     if: >-
       github.actor == github.repository_owner &&
       ((github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') ||
-       (github.event_name == 'issue_comment' && github.event.issue.number == 98 && github.event.comment.body == '/run-opencode-v11'))
+       (github.event_name == 'issue_comment' && github.event.issue.number == 100 && github.event.comment.body == '/run-opencode-v12'))
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     env:
@@ -26,7 +26,7 @@ jobs:
       OLLAMA_ARCHIVE_SHA256: 88e0d36bd90121595e5516c84f6ab61b546368fbd2d825b4aae70999c949649d
       OPENCODE_VERSION: v1.18.23
       OPENCODE_ARCHIVE_SHA256: ab7015cd8113e011a461f30a0c2b77d8299a144ff688cb62e93e8802835d7288
-      OPENCODE_OLLAMA_MODEL: functiongemma:270m
+      OPENCODE_OLLAMA_MODEL: qwen3:0.6b
     steps:
       - name: Checkout trusted Factory main
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
## Summary

Creates immutable OpenCode/Ollama live pilot v12 after v11 proved the native `/api/chat` bridge returns structured tool calls but FunctionGemma 270M selected an unexpected function name.

Only the live pilot harness changes:
- owner-authorized trigger moves to issue #100 `/run-opencode-v12`;
- local model changes from `functiongemma:270m` to Ollama-published `qwen3:0.6b`;
- all native bridge semantics and guardrails stay unchanged.

The shim still accepts only exactly one real structured native `write` call with object arguments. It never interprets plain text or unexpected function names as success. Provider shell remains disabled, trusted runtime retains sole commit/push authority, exact-SHA CI remains mandatory, target merge/production remain forbidden, and Codex remains excluded.