### PR TITLE
test: run native Qwen3 1.7B exact-write pilot v14

### DIFF
--- a/.github/workflows/live-opencode-ollama-pilot.yml
+++ b/.github/workflows/live-opencode-ollama-pilot.yml
@@ -10,15 +10,15 @@ permissions:
   contents: write
 
 concurrency:
-  group: ${{ (github.event_name == 'workflow_dispatch' || (github.event_name == 'issue_comment' && github.event.issue.number == 102 && github.event.comment.body == '/run-opencode-v13')) && 'live-opencode-ollama-provider-pilot' || format('live-opencode-ollama-noop-{0}', github.run_id) }}
-  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'issue_comment' && github.event.issue.number == 102 && github.event.comment.body == '/run-opencode-v13') }}
+  group: ${{ (github.event_name == 'workflow_dispatch' || (github.event_name == 'issue_comment' && github.event.issue.number == 104 && github.event.comment.body == '/run-opencode-v14')) && 'live-opencode-ollama-provider-pilot' || format('live-opencode-ollama-noop-{0}', github.run_id) }}
+  cancel-in-progress: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'issue_comment' && github.event.issue.number == 104 && github.event.comment.body == '/run-opencode-v14') }}
 
 jobs:
   live-pilot:
     if: >-
       github.actor == github.repository_owner &&
       ((github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') ||
-       (github.event_name == 'issue_comment' && github.event.issue.number == 102 && github.event.comment.body == '/run-opencode-v13'))
+       (github.event_name == 'issue_comment' && github.event.issue.number == 104 && github.event.comment.body == '/run-opencode-v14'))
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     env:
@@ -26,7 +26,7 @@ jobs:
       OLLAMA_ARCHIVE_SHA256: 88e0d36bd90121595e5516c84f6ab61b546368fbd2d825b4aae70999c949649d
       OPENCODE_VERSION: v1.18.23
       OPENCODE_ARCHIVE_SHA256: ab7015cd8113e011a461f30a0c2b77d8299a144ff688cb62e93e8802835d7288
-      OPENCODE_OLLAMA_MODEL: qwen3:0.6b
+      OPENCODE_OLLAMA_MODEL: qwen3:1.7b
     steps:
       - name: Checkout trusted Factory main
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
## Summary

Creates immutable live pilot v14 after Qwen3 0.6B proved real native `write + commit + push` but omitted only the required final newline.

Only the live pilot harness changes:
- owner-authorized trigger moves to issue #104 `/run-opencode-v14`;
- model changes from `qwen3:0.6b` to `qwen3:1.7b`;
- exact JSON argument instruction, immutable expected bytes, native bridge and all guardrails remain unchanged.

No runtime/proxy validation is weakened. Provider shell remains disabled, trusted runtime retains sole commit/push authority, exact-SHA CI remains mandatory, target merge/production remain forbidden, and Codex remains excluded.