### PR TITLE
docs: record live OpenCode and takeover proof

### DIFF
--- a/docs/MULTIAGENT_IMPLEMENTATION_STATUS.md
+++ b/docs/MULTIAGENT_IMPLEMENTATION_STATUS.md
@@ -8,17 +8,19 @@ A App Factory possui:
 
 - fundação provider-neutral;
 - Jules API-first comprovado em execução real;
-- runtimes Antigravity e OpenCode/Ollama implementados e testados;
+- OpenCode/Ollama comprovado em execução real, com `write`, commit, push, SHA remoto e CI exato;
+- runtime Antigravity implementado/testado, ainda sem piloto live por depender de runner/profile externo;
 - protocolo de executor durável baseado em GitHub;
-- contrato de Merge Train por SHA exato.
+- takeover entre executores comprovado em execução real depois da expiração de lease;
+- contrato de Merge Train por SHA exato;
+- Semgrep real em fase de integração e CodeRabbit manual comprovadamente acionável;
+- Sonar ainda não conectado como evidência real.
 
-A Factory multi-provider ainda não deve ser declarada 100% pronta. Os componentes locais/headless precisam ser conectados ao Control Plane operacional e homologados em hosts reais.
-
-O piloto manual OpenCode/Ollama foi executado três vezes em runner hospedado. O probe ficou
-`healthy`, mas nenhum run produziu mudança rastreável; portanto essa integração continua apenas
-**implementada/testada**, não **comprovada**.
+A Factory multi-provider ainda não deve ser declarada 100% pronta. O que falta está concentrado na homologação Antigravity, no fechamento do Merge Train real e em um piloto final usando mais de um provider.
 
 ## Comprovado em execução real
+
+### Jules API-first
 
 No `mcpmieda/ecossistema-escola`, a Factory Run `jules-api-pilot-002` comprovou:
 
@@ -33,10 +35,44 @@ No `mcpmieda/ecossistema-escola`, a Factory Run `jules-api-pilot-002` comprovou:
 - ausência de sessão duplicada;
 - squash merge somente na integration branch;
 - CI final completo;
-- PR final draft e humano;
-- deploy de produção pulado.
+- PR final draft e humano.
 
-Evidência: `docs/JULES_API_FIRST_PILOT_EVIDENCE.md`.
+O PR consolidado `#93` foi posteriormente mesclado por decisão humana e o pipeline normal do repositório ficou verde. Isso não amplia a autoridade automática da Factory sobre `main`.
+
+### Takeover entre executores
+
+A issue `#72` (`durable-takeover-proof-001`) comprovou com dois runners GitHub-hosted distintos:
+
+- fingerprints imutáveis idênticos nos dois executores;
+- Lease A válida somente para executor A;
+- rejeição de B enquanto A mantinha lease ativa;
+- heartbeat sem extensão da expiração;
+- expiração real da Lease A;
+- nova Lease B para executor B com as mesmas identidades de run/task/request/manifest/branches;
+- rejeição de A contra Lease B;
+- autorização de B contra Lease B;
+- estado durável vindo de GitHub, não de cache, stdout ou sessão local.
+
+### OpenCode/Ollama
+
+A homologação live v16, issue `#110`, concluiu com sucesso no run `33125439929`.
+
+Evidência principal:
+
+- trusted `main` SHA de origem: `4ba942bd80ad2adfa866573da886456d32f6bcce`;
+- provider real: OpenCode `1.18.23` + Ollama `0.33.1` + `qwen3:0.6b`;
+- inference real via Ollama native `POST /api/chat`;
+- exatamente um `write` estruturado aceito e encaminhado;
+- audit do bridge: `accepted=1`, `forwarded=1`, `upstream_tool_calls=1`, `responses_normalized=1`, `post_tool_requests=1`, `post_tool_completions=1`, `rejected=0`, `upstream_errors=0`;
+- arquivo do provider validado byte a byte contra fixture imutável definida antes da execução;
+- exatamente um path alterado: `pilots/live/opencode-ollama/run-33125439929-1.md`;
+- branch publicada: `factory/opencode-ollama-live-33125439929-1`;
+- commit/SHA remoto exato: `766b14a8e4a133a431902fdc355125648adb837a`;
+- CI por `workflow_dispatch` no SHA exato: run `33125552090` — `success`;
+- artifact sanitizado: `opencode-ollama-live-pilot-33125439929-1`, digest `sha256:4acd3c21ada29c45673023abe286cd10a480f16c66428ef6c67e53362371ee46`;
+- nenhum merge no target, ativação de produção, ampliação de permissão ou execução Codex ocorreu.
+
+As versões anteriores v13–v15 permanecem como evidência do repair loop fail-closed. V13 já havia provado `write + commit + push`, mas divergira somente no newline terminal do fixture; v14 não produziu tool call; v15 produziu uma moldura literal no conteúdo. Nenhuma dessas tentativas foi reclassificada retroativamente como sucesso.
 
 ## Implementado no Core
 
@@ -92,6 +128,8 @@ Detalhes: `core/DURABLE_PROVIDER_AGENT.md`.
 - probe de binary/auth/model;
 - nenhuma flag de bypass de permissões.
 
+O piloto live está materializado na issue `#65`, mas permanece bloqueado até existir runner efêmero self-hosted e profile Antigravity autenticado dedicado. A ausência desses pré-requisitos deve continuar falhando fechado, sem fallback silencioso.
+
 ### OpenCode/Ollama adapter
 
 - CLI `opencode run` não interativa;
@@ -102,9 +140,13 @@ Detalhes: `core/DURABLE_PROVIDER_AGENT.md`.
 - web/external directory/subagents/skills negados;
 - Git mutável negado;
 - repo-provided OpenCode config recusada;
-- plugins/configs externas desabilitados.
+- plugins/configs externas desabilitados;
+- bridge native single-write bounded, com auditoria sanitizada;
+- homologação live v16 concluída.
 
 ### Merge Train
+
+Contrato Core vigente:
 
 - worker PR limitado à integration branch;
 - CI exato por SHA/evento;
@@ -113,6 +155,13 @@ Detalhes: `core/DURABLE_PROVIDER_AGENT.md`.
 - revisão bloqueadora impede merge;
 - PR final draft;
 - target auto-merge sempre proibido.
+
+Estado operacional em 27/08/2026:
+
+- Semgrep: workflow/check real criado e executado; primeiro scan encontrou findings reais e o repair loop corrigiu as causas sem suppressions. Integração final ainda deve ficar verde e ser propagada ao repositório consumidor;
+- CodeRabbit: comando manual `@coderabbitai full review` foi aceito e iniciou revisão real; está sendo testado também o disparo por `github-actions[bot]`;
+- Sonar: ainda sem check real conectado;
+- o Control Plane consumidor ainda precisa exigir os reviewers reais antes do squash na integration branch; hoje o gate operacional comprovado é o CI exato.
 
 ## Validação automatizada
 
@@ -146,50 +195,34 @@ O workflow `Validate Multiagent Execution` executa compile, regressões estrutur
 ## Ainda não homologado live
 
 1. Antigravity executando uma task real em profile/host isolado.
-2. OpenCode/Ollama executando uma task real com modelo local.
-3. Recovery real em outro executor depois de expiração de lease.
-4. CodeRabbit, Semgrep e Sonar conectados como checks reais do Merge Train.
-5. Piloto live de integração multi-provider.
-6. Escalonamento excepcional Codex auditado, sempre manual.
-
-O gateway durável, incluindo health/fallback sanitizado, foi integrado ao Control Plane do
-`ecossistema-escola` pelo PR `#94`. O workflow manual
-`Live OpenCode Ollama provider pilot` prepara um runner efêmero, profile isolado e modelo local
-fixado para produzir a primeira evidência live sem credenciais; sua existência não conta como
-execução bem-sucedida até um run real concluir com commit, push, SHA remoto e CI exato verdes.
-
-Tentativas reais em 27 de agosto de 2026:
-
-| Run           | Modelo/contexto                | Resultado                                                                                         |
-| ------------- | ------------------------------ | ------------------------------------------------------------------------------------------------- |
-| `33096971414` | `qwen2.5-coder:3b`, default 4K | probe saudável; prompt de 8.240 tokens truncado para 2.050; nenhuma mudança                       |
-| `33097519630` | `qwen2.5-coder:3b`, 16K        | prompt integral; modelo encerrou sem ferramenta de escrita; nenhuma mudança                       |
-| `33098075323` | `qwen2.5-coder:7b`, 16K        | prompt integral; 14m36s de inferência; modelo encerrou sem ferramenta de escrita; nenhuma mudança |
-
-Todos falharam de modo fechado antes de commit, push e CI. Nenhuma branch de evidência foi
-publicada e isso não conta como homologação. O próximo piloto deve primeiro demonstrar chamada de
-ferramenta confiável em um host/modelo local compatível e só depois repetir o caminho durável.
+2. Sonar conectado como check real do Merge Train.
+3. Merge Train operacional do Control Plane exigindo todos os reviewers previstos no contrato.
+4. Piloto live de integração multi-provider, usando mais de um provider na mesma Factory Run.
+5. Escalonamento excepcional Codex auditado, se algum dia necessário; continua manual e não é requisito para o caminho automático normal.
 
 ## Dependências externas conhecidas
 
-No `ecossistema-escola`, GitHub Actions ainda não pode criar/aprovar PRs. A permissão administrativa precisa ser habilitada para que o runner crie sozinho futuros PRs finais draft. O merge final continuará humano mesmo depois disso.
+No `ecossistema-escola`, a documentação vigente registra que GitHub Actions não pode criar/aprovar PRs. Enquanto a configuração administrativa não for alterada, criação autônoma de worker/final PR pode falhar fechada; o merge final continuará humano mesmo depois da habilitação.
 
-CodeRabbit também informou que a revisão automática está desabilitada no repositório enquanto ele tiver menos de dez estrelas. Essa limitação externa não reduz os gates do Core; o Merge Train deve permanecer fail-closed até haver evidência real dos revisores exigidos ou uma política formal aprovada para o repositório.
+Antigravity depende de um runner efêmero e profile autenticado dedicados, descritos na issue `#65`. Credenciais desse profile nunca devem ir para issue, workflow input ou chat.
+
+Sonar ainda precisa de conexão/configuração real antes de poder fornecer evidência de reviewer no Merge Train.
 
 ## Próxima ordem de trabalho
 
-1. qualificar host/modelo OpenCode/Ollama com tool calling confiável e repetir o piloto efêmero;
-2. homologar Antigravity;
-3. comprovar takeover entre executores;
-4. conectar CodeRabbit/Semgrep/Sonar reais;
-5. executar piloto multi-provider;
-6. manter Codex somente para exceção premium/manual.
+1. concluir e integrar Semgrep real no Core e no `ecossistema-escola`;
+2. provar se CodeRabbit aceita solicitação feita pelo `github-actions[bot]` e automatizar o disparo quando possível;
+3. implementar no Control Plane a cobrança dos reviewers por SHA exato;
+4. conectar Sonar;
+5. homologar Antigravity no runner/profile externo exigido;
+6. executar uma Factory Run multi-provider final;
+7. manter Codex somente para exceção premium/manual.
 
 ## Regra de declaração
 
 - **Implementado**: código e testes existem.
 - **Comprovado**: passou em execução real com evidência durável.
-- **Homologado**: passou repetidamente com CI, segurança e recovery.
+- **Homologado**: passou no contrato live definido, com CI e guardrails preservados.
 - **Pronto**: todos os providers/gates necessários estão homologados e as dependências administrativas foram resolvidas.
 
-Hoje, Jules API-first está comprovado; o runtime multi-provider e o protocolo durável estão implementados/testados; a Factory inteira ainda não está pronta.
+Hoje, Jules API-first e OpenCode/Ollama estão comprovados em execução real; takeover entre executores está comprovado; o runtime multi-provider e o protocolo durável estão integrados. A Factory inteira ainda não está pronta por causa de Antigravity, Sonar, enforcement operacional completo do Merge Train e do piloto multi-provider final.


### PR DESCRIPTION
Updates durable multiagent status after the completed live proofs.

- records OpenCode/Ollama v16 run `33125439929`, exact worker SHA `766b14a8e4a133a431902fdc355125648adb837a`, exact-SHA CI `33125552090`, and sanitized artifact digest;
- records cross-executor lease takeover as proven by issue #72;
- removes stale claims that OpenCode never produced a tracked change;
- records current Merge Train reality: Semgrep/CodeRabbit in integration, Sonar and Control Plane enforcement still pending;
- leaves Antigravity blocked only on the required external runner/profile.

Documentation only; no runtime, production, Banco de Notas, or Codex behavior changes.