### PR TITLE
feat: prepare credential-separated Antigravity live pilot v2

### DIFF
--- a/.github/workflows/live-antigravity-pilot.yml
+++ b/.github/workflows/live-antigravity-pilot.yml
@@ -117,10 +117,10 @@ jobs:
 
       - name: Probe Antigravity with isolated cached authentication
         shell: bash
-        working-directory: ${{ env.FACTORY_PROVIDER_WORKTREE }}
         run: |
           set -euo pipefail
-          python3 "${GITHUB_WORKSPACE}/scripts/provider_worker.py" probe \
+          cd "${FACTORY_PROVIDER_WORKTREE}"
+          python3 scripts/provider_worker.py probe \
             --provider antigravity \
             --binary agy \
             --profile-home "${FACTORY_ANTIGRAVITY_PROFILE}" \
@@ -129,12 +129,12 @@ jobs:
 
       - name: Execute and stage validated provider commit
         shell: bash
-        working-directory: ${{ env.FACTORY_PROVIDER_WORKTREE }}
         run: |
           set -euo pipefail
+          cd "${FACTORY_PROVIDER_WORKTREE}"
           stage_dir="${RUNNER_TEMP}/antigravity-stage"
           mkdir -p "${stage_dir}"
-          python3 "${GITHUB_WORKSPACE}/scripts/provider_worker.py" stage \
+          python3 scripts/provider_worker.py stage \
             --provider antigravity \
             --binary agy \
             --profile-home "${FACTORY_ANTIGRAVITY_PROFILE}" \
@@ -244,7 +244,8 @@ jobs:
               if record.get(key) != value:
                   raise SystemExit(f"stage record contract mismatch: {key}")
           for key in ("start_sha", "commit_sha", "bundle_sha256"):
-              if not re.fullmatch(r"[0-9a-f]{40}" if key != "bundle_sha256" else r"[0-9a-f]{64}", str(record.get(key) or "")):
+              pattern = r"[0-9a-f]{64}" if key == "bundle_sha256" else r"[0-9a-f]{40}"
+              if not re.fullmatch(pattern, str(record.get(key) or "")):
                   raise SystemExit(f"invalid stage record {key}")
           if record["start_sha"] != os.environ["GITHUB_SHA"]:
               raise SystemExit("staged base SHA differs from trusted workflow SHA")

--- a/.github/workflows/live-antigravity-pilot.yml
+++ b/.github/workflows/live-antigravity-pilot.yml
@@ -1,0 +1,407 @@
+name: Live Antigravity staged provider pilot
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions: {}
+
+concurrency:
+  group: antigravity-live-pilot-002
+  cancel-in-progress: false
+
+jobs:
+  provider-stage:
+    name: Stage Antigravity result without publication credentials
+    if: >-
+      github.actor == github.repository_owner &&
+      github.event.issue.number == 115 &&
+      github.event.comment.body == '/run-antigravity-v2'
+    runs-on: [self-hosted, Linux, X64, factory-antigravity, ephemeral]
+    timeout-minutes: 45
+    permissions: {}
+    outputs:
+      artifact_digest: ${{ steps.upload.outputs.artifact-digest }}
+    env:
+      PILOT_RUN_ID: antigravity-live-pilot-002
+      PILOT_TASK_ID: antigravity-worker
+      PILOT_TARGET_BRANCH: main
+      PILOT_INTEGRATION_BRANCH: factory/antigravity-live-pilot-002
+      PILOT_WORKER_BRANCH: factory/antigravity-live-pilot-002-antigravity-worker
+      PILOT_FILE: docs/provider-pilots/antigravity-live-pilot-002/RESULT.txt
+      ANTIGRAVITY_PROFILE_HOME: ${{ vars.ANTIGRAVITY_PROFILE_HOME }}
+    steps:
+      - name: Prepare public checkout with no GitHub credential
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "${GITHUB_REF}" = "refs/heads/main"
+          worktree="${RUNNER_TEMP}/provider-worktree"
+          git_home="${RUNNER_TEMP}/credential-free-git-home"
+          mkdir -p "${worktree}" "${git_home}"
+          export HOME="${git_home}"
+          export GIT_CONFIG_NOSYSTEM=1
+          export GIT_TERMINAL_PROMPT=0
+          git init "${worktree}"
+          git -C "${worktree}" remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          git -C "${worktree}" -c credential.helper= fetch --depth=1 origin "${GITHUB_SHA}"
+          git -C "${worktree}" checkout -b "${PILOT_WORKER_BRANCH}" FETCH_HEAD
+          git -C "${worktree}" config user.name "github-actions[bot]"
+          git -C "${worktree}" config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          test "$(git -C "${worktree}" rev-parse HEAD)" = "${GITHUB_SHA}"
+          if git -C "${worktree}" config --local --get-regexp '^(credential\.|http\..*\.extraheader)' >/dev/null 2>&1; then
+            echo 'credential-bearing Git configuration is forbidden in provider stage' >&2
+            exit 1
+          fi
+          echo "FACTORY_PROVIDER_WORKTREE=${worktree}" >> "${GITHUB_ENV}"
+
+      - name: Verify ephemeral executor and isolated Antigravity profile
+        shell: bash
+        run: |
+          set -euo pipefail
+          command -v agy >/dev/null
+          command -v git >/dev/null
+          command -v python3 >/dev/null
+          test -n "${ANTIGRAVITY_PROFILE_HOME}"
+          profile=$(realpath -e "${ANTIGRAVITY_PROFILE_HOME}")
+          worktree=$(realpath -e "${FACTORY_PROVIDER_WORKTREE}")
+          case "${profile}/" in
+            "${worktree}/"*) echo 'Antigravity profile must be outside worktree' >&2; exit 1 ;;
+          esac
+          for forbidden in .git-credentials .netrc .config/gh/hosts.yml; do
+            test ! -e "${profile}/${forbidden}" || {
+              echo "unrelated publication credential is forbidden in Antigravity profile: ${forbidden}" >&2
+              exit 1
+            }
+          done
+          if env | grep -Eq '^(GITHUB_TOKEN|GH_TOKEN|FACTORY_GITHUB_TOKEN)='; then
+            echo 'GitHub publication token unexpectedly present in provider job environment' >&2
+            exit 1
+          fi
+          echo "FACTORY_ANTIGRAVITY_PROFILE=${profile}" >> "${GITHUB_ENV}"
+
+      - name: Build immutable provider request
+        shell: bash
+        run: |
+          set -euo pipefail
+          export PILOT_RUN_ID PILOT_TASK_ID PILOT_TARGET_BRANCH PILOT_INTEGRATION_BRANCH PILOT_WORKER_BRANCH PILOT_FILE
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          request = {
+              "run_id": os.environ["PILOT_RUN_ID"],
+              "task_id": os.environ["PILOT_TASK_ID"],
+              "repository": os.environ["GITHUB_REPOSITORY"],
+              "worktree": os.environ["FACTORY_PROVIDER_WORKTREE"],
+              "integration_branch": os.environ["PILOT_INTEGRATION_BRANCH"],
+              "target_branch": os.environ["PILOT_TARGET_BRANCH"],
+              "working_branch": os.environ["PILOT_WORKER_BRANCH"],
+              "paths": [os.environ["PILOT_FILE"]],
+              "instruction": (
+                  "Create only the declared RESULT.txt file with a concise statement that the "
+                  "Antigravity live provider execution completed successfully. Do not edit any "
+                  "other path. Do not use Git, do not push, do not modify repository metadata, "
+                  "and do not include credentials, tokens, secrets, passwords or authorization data."
+              ),
+              "allowed_commands": [],
+              "timeout_seconds": 1800,
+              "remote": "origin",
+          }
+          Path(os.environ["RUNNER_TEMP"], "provider-task.json").write_text(
+              json.dumps(request, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+          PY
+
+      - name: Probe Antigravity with isolated cached authentication
+        shell: bash
+        working-directory: ${{ env.FACTORY_PROVIDER_WORKTREE }}
+        run: |
+          set -euo pipefail
+          python3 "${GITHUB_WORKSPACE}/scripts/provider_worker.py" probe \
+            --provider antigravity \
+            --binary agy \
+            --profile-home "${FACTORY_ANTIGRAVITY_PROFILE}" \
+            > "${RUNNER_TEMP}/provider-health.json"
+          cat "${RUNNER_TEMP}/provider-health.json"
+
+      - name: Execute and stage validated provider commit
+        shell: bash
+        working-directory: ${{ env.FACTORY_PROVIDER_WORKTREE }}
+        run: |
+          set -euo pipefail
+          stage_dir="${RUNNER_TEMP}/antigravity-stage"
+          mkdir -p "${stage_dir}"
+          python3 "${GITHUB_WORKSPACE}/scripts/provider_worker.py" stage \
+            --provider antigravity \
+            --binary agy \
+            --profile-home "${FACTORY_ANTIGRAVITY_PROFILE}" \
+            --effort medium \
+            --bundle "${stage_dir}/provider.bundle" \
+            --record "${stage_dir}/stage-record.json" \
+            "${RUNNER_TEMP}/provider-task.json" \
+            > "${RUNNER_TEMP}/stage-summary.json"
+          cat "${RUNNER_TEMP}/stage-summary.json"
+          if pgrep -x agy >/dev/null 2>&1; then
+            echo 'Antigravity process still alive after stage completion; publication is forbidden' >&2
+            exit 1
+          fi
+          mapfile -t files < <(find "${stage_dir}" -maxdepth 1 -type f -printf '%f\n' | sort)
+          test "${#files[@]}" -eq 2
+          test "${files[0]}" = "provider.bundle"
+          test "${files[1]}" = "stage-record.json"
+
+      - name: Upload only sanitized staged publication artifact
+        id: upload
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: antigravity-stage-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/antigravity-stage
+          if-no-files-found: error
+          retention-days: 7
+          compression-level: 0
+
+  trusted-publisher:
+    name: Validate staged bundle and publish through trusted GitHub job
+    needs: provider-stage
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      actions: write
+      contents: write
+      issues: write
+      pull-requests: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      PILOT_RUN_ID: antigravity-live-pilot-002
+      PILOT_TASK_ID: antigravity-worker
+      PILOT_TARGET_BRANCH: main
+      PILOT_INTEGRATION_BRANCH: factory/antigravity-live-pilot-002
+      PILOT_WORKER_BRANCH: factory/antigravity-live-pilot-002-antigravity-worker
+      PILOT_FILE: docs/provider-pilots/antigravity-live-pilot-002/RESULT.txt
+      EXPECTED_ARTIFACT_DIGEST: ${{ needs.provider-stage.outputs.artifact_digest }}
+      ARTIFACT_NAME: antigravity-stage-${{ github.run_id }}-${{ github.run_attempt }}
+    steps:
+      - name: Checkout exact trusted pilot authority
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+
+      - name: Download staged provider artifact
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: ${{ env.ARTIFACT_NAME }}
+          path: ${{ runner.temp }}/antigravity-stage
+
+      - name: Verify artifact service digest and exact file surface
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -n "${EXPECTED_ARTIFACT_DIGEST}"
+          service_digest=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/artifacts" \
+            --jq ".artifacts[] | select(.name == \"${ARTIFACT_NAME}\") | .digest" | head -n 1)
+          test -n "${service_digest}"
+          test "${service_digest}" = "${EXPECTED_ARTIFACT_DIGEST}"
+          stage_dir="${RUNNER_TEMP}/antigravity-stage"
+          mapfile -t files < <(find "${stage_dir}" -maxdepth 1 -type f -printf '%f\n' | sort)
+          test "${#files[@]}" -eq 2
+          test "${files[0]}" = "provider.bundle"
+          test "${files[1]}" = "stage-record.json"
+
+      - name: Validate immutable stage record
+        shell: bash
+        run: |
+          set -euo pipefail
+          export PILOT_RUN_ID PILOT_TASK_ID PILOT_TARGET_BRANCH PILOT_INTEGRATION_BRANCH PILOT_WORKER_BRANCH PILOT_FILE
+          python3 - <<'PY'
+          import hashlib
+          import json
+          import os
+          import re
+          from pathlib import Path
+
+          root = Path(os.environ["RUNNER_TEMP"], "antigravity-stage")
+          record = json.loads((root / "stage-record.json").read_text(encoding="utf-8"))
+          exact = {
+              "schema_version": 1,
+              "provider": "antigravity",
+              "run_id": os.environ["PILOT_RUN_ID"],
+              "task_id": os.environ["PILOT_TASK_ID"],
+              "repository": os.environ["GITHUB_REPOSITORY"],
+              "integration_branch": os.environ["PILOT_INTEGRATION_BRANCH"],
+              "target_branch": os.environ["PILOT_TARGET_BRANCH"],
+              "working_branch": os.environ["PILOT_WORKER_BRANCH"],
+              "declared_paths": [os.environ["PILOT_FILE"]],
+              "changed_paths": [os.environ["PILOT_FILE"]],
+              "github_run_id": os.environ["GITHUB_RUN_ID"],
+              "github_run_attempt": os.environ["GITHUB_RUN_ATTEMPT"],
+              "github_sha": os.environ["GITHUB_SHA"],
+          }
+          for key, value in exact.items():
+              if record.get(key) != value:
+                  raise SystemExit(f"stage record contract mismatch: {key}")
+          for key in ("start_sha", "commit_sha", "bundle_sha256"):
+              if not re.fullmatch(r"[0-9a-f]{40}" if key != "bundle_sha256" else r"[0-9a-f]{64}", str(record.get(key) or "")):
+                  raise SystemExit(f"invalid stage record {key}")
+          if record["start_sha"] != os.environ["GITHUB_SHA"]:
+              raise SystemExit("staged base SHA differs from trusted workflow SHA")
+          digest = hashlib.sha256((root / "provider.bundle").read_bytes()).hexdigest()
+          if digest != record["bundle_sha256"]:
+              raise SystemExit("provider bundle digest mismatch")
+          forbidden = {"instruction", "response", "session_id", "profile_home", "provider_output"}
+          if forbidden.intersection(record):
+              raise SystemExit("stage record contains forbidden raw provider material")
+          PY
+
+      - name: Verify bundle history, scope and credential hygiene
+        id: bundle
+        shell: bash
+        run: |
+          set -euo pipefail
+          stage_dir="${RUNNER_TEMP}/antigravity-stage"
+          record="${stage_dir}/stage-record.json"
+          staged_sha=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["commit_sha"])' "${record}")
+          start_sha=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["start_sha"])' "${record}")
+          git bundle verify "${stage_dir}/provider.bundle"
+          git fetch "${stage_dir}/provider.bundle" \
+            "refs/heads/${PILOT_WORKER_BRANCH}:refs/remotes/staged/worker"
+          test "$(git rev-parse refs/remotes/staged/worker)" = "${staged_sha}"
+          test "$(git rev-parse HEAD)" = "${start_sha}"
+          git merge-base --is-ancestor "${start_sha}" "${staged_sha}"
+          test "$(git rev-list --count "${start_sha}..${staged_sha}")" -eq 1
+          test -z "$(git rev-list --merges "${start_sha}..${staged_sha}")"
+          mapfile -t changed < <(git diff --name-only "${start_sha}" "${staged_sha}")
+          test "${#changed[@]}" -eq 1
+          test "${changed[0]}" = "${PILOT_FILE}"
+          mode=$(git ls-tree "${staged_sha}" -- "${PILOT_FILE}" | awk '{print $1}')
+          test "${mode}" = "100644"
+          size=$(git cat-file -s "${staged_sha}:${PILOT_FILE}")
+          test "${size}" -gt 0
+          test "${size}" -le 65536
+          git show "${staged_sha}:${PILOT_FILE}" > "${RUNNER_TEMP}/validated-result.txt"
+          python3 - <<'PY'
+          import os
+          from pathlib import Path
+          from engine.provider_runtime import redact_text
+
+          path = Path(os.environ["RUNNER_TEMP"], "validated-result.txt")
+          raw = path.read_bytes()
+          if b"\x00" in raw:
+              raise SystemExit("provider result contains NUL bytes")
+          text = raw.decode("utf-8")
+          if redact_text(text, limit=len(text) + 1) != text:
+              raise SystemExit("provider result matches credential pattern")
+          PY
+          echo "staged_sha=${staged_sha}" >> "${GITHUB_OUTPUT}"
+          echo "start_sha=${start_sha}" >> "${GITHUB_OUTPUT}"
+
+      - name: Create isolated refs only after bundle validation
+        shell: bash
+        env:
+          STAGED_SHA: ${{ steps.bundle.outputs.staged_sha }}
+          START_SHA: ${{ steps.bundle.outputs.start_sha }}
+        run: |
+          set -euo pipefail
+          if git ls-remote --exit-code origin "refs/heads/${PILOT_INTEGRATION_BRANCH}" >/dev/null 2>&1; then
+            echo 'pilot integration branch already exists; refusing replay' >&2
+            exit 1
+          fi
+          if git ls-remote --exit-code origin "refs/heads/${PILOT_WORKER_BRANCH}" >/dev/null 2>&1; then
+            echo 'pilot worker branch already exists; refusing replay' >&2
+            exit 1
+          fi
+          git push origin \
+            "${START_SHA}:refs/heads/${PILOT_INTEGRATION_BRANCH}" \
+            "${STAGED_SHA}:refs/heads/${PILOT_WORKER_BRANCH}"
+          test "$(git ls-remote origin "refs/heads/${PILOT_WORKER_BRANCH}" | awk '{print $1}')" = "${STAGED_SHA}"
+          test "$(git ls-remote origin "refs/heads/${PILOT_INTEGRATION_BRANCH}" | awk '{print $1}')" = "${START_SHA}"
+
+      - name: Create worker PR and run exact-SHA CI
+        id: worker
+        shell: bash
+        env:
+          STAGED_SHA: ${{ steps.bundle.outputs.staged_sha }}
+        run: |
+          set -euo pipefail
+          worker_url=$(gh pr create \
+            --base "${PILOT_INTEGRATION_BRANCH}" \
+            --head "${PILOT_WORKER_BRANCH}" \
+            --title "[Factory:${PILOT_RUN_ID}] Antigravity staged worker" \
+            --body "Credential-separated Antigravity live pilot. Provider stage had no GitHub publication credential. Target merge and production remain forbidden.")
+          worker_pr=$(gh pr view "${worker_url}" --json number --jq '.number')
+          gh workflow run validate-multiagent-execution.yml --ref "${PILOT_WORKER_BRANCH}"
+          ci_run=""
+          for attempt in $(seq 1 60); do
+            ci_run=$(gh run list \
+              --workflow validate-multiagent-execution.yml \
+              --branch "${PILOT_WORKER_BRANCH}" \
+              --event workflow_dispatch \
+              --limit 20 \
+              --json databaseId,headSha \
+              --jq ".[] | select(.headSha == \"${STAGED_SHA}\") | .databaseId" | head -n 1)
+            if [ -n "${ci_run}" ]; then break; fi
+            sleep 2
+          done
+          test -n "${ci_run}"
+          gh run watch "${ci_run}" --exit-status
+          test "$(gh pr view "${worker_pr}" --json headRefOid --jq '.headRefOid')" = "${STAGED_SHA}"
+          echo "worker_pr=${worker_pr}" >> "${GITHUB_OUTPUT}"
+          echo "worker_ci=${ci_run}" >> "${GITHUB_OUTPUT}"
+
+      - name: Merge worker only into isolated integration branch
+        id: integrate
+        shell: bash
+        env:
+          WORKER_PR: ${{ steps.worker.outputs.worker_pr }}
+        run: |
+          set -euo pipefail
+          test "$(gh pr view "${WORKER_PR}" --json baseRefName --jq '.baseRefName')" = "${PILOT_INTEGRATION_BRANCH}"
+          gh pr merge "${WORKER_PR}" --squash --delete-branch=false
+          integration_sha=$(git ls-remote origin "refs/heads/${PILOT_INTEGRATION_BRANCH}" | awk '{print $1}')
+          test -n "${integration_sha}"
+          echo "integration_sha=${integration_sha}" >> "${GITHUB_OUTPUT}"
+
+      - name: Run exact-SHA integration CI
+        id: integration-ci
+        shell: bash
+        env:
+          INTEGRATION_SHA: ${{ steps.integrate.outputs.integration_sha }}
+        run: |
+          set -euo pipefail
+          gh workflow run validate-multiagent-execution.yml --ref "${PILOT_INTEGRATION_BRANCH}"
+          ci_run=""
+          for attempt in $(seq 1 60); do
+            ci_run=$(gh run list \
+              --workflow validate-multiagent-execution.yml \
+              --branch "${PILOT_INTEGRATION_BRANCH}" \
+              --event workflow_dispatch \
+              --limit 20 \
+              --json databaseId,headSha \
+              --jq ".[] | select(.headSha == \"${INTEGRATION_SHA}\") | .databaseId" | head -n 1)
+            if [ -n "${ci_run}" ]; then break; fi
+            sleep 2
+          done
+          test -n "${ci_run}"
+          gh run watch "${ci_run}" --exit-status
+          echo "integration_ci=${ci_run}" >> "${GITHUB_OUTPUT}"
+
+      - name: Create final draft human gate and persist evidence
+        shell: bash
+        env:
+          STAGED_SHA: ${{ steps.bundle.outputs.staged_sha }}
+          WORKER_PR: ${{ steps.worker.outputs.worker_pr }}
+          WORKER_CI: ${{ steps.worker.outputs.worker_ci }}
+          INTEGRATION_SHA: ${{ steps.integrate.outputs.integration_sha }}
+          INTEGRATION_CI: ${{ steps.integration-ci.outputs.integration_ci }}
+        run: |
+          set -euo pipefail
+          final_url=$(gh pr create \
+            --draft \
+            --base "${PILOT_TARGET_BRANCH}" \
+            --head "${PILOT_INTEGRATION_BRANCH}" \
+            --title "[Factory:${PILOT_RUN_ID}] consolidated Antigravity result" \
+            --body "Antigravity credential-separated live proof. Worker PR #${WORKER_PR}; staged SHA ${STAGED_SHA}; worker CI ${WORKER_CI}; integration SHA ${INTEGRATION_SHA}; integration CI ${INTEGRATION_CI}. Final target merge remains human-only. Production, Banco de Notas sync and Codex were not activated.")
+          gh issue comment 115 --body "Antigravity v2 live pilot completed through credential-separated publication. Worker PR #${WORKER_PR}; worker CI ${WORKER_CI}; integration CI ${INTEGRATION_CI}; final draft PR ${final_url}. No target merge or production activation was performed."

--- a/.github/workflows/validate-multiagent-execution.yml
+++ b/.github/workflows/validate-multiagent-execution.yml
@@ -19,6 +19,7 @@ on:
       - "core/MERGE_TRAIN.md"
       - "docs/MULTIAGENT_IMPLEMENTATION_STATUS.md"
       - "docs/JULES_API_FIRST_PILOT_EVIDENCE.md"
+      - ".github/workflows/live-antigravity-pilot.yml"
       - ".github/workflows/live-opencode-ollama-pilot.yml"
       - ".github/workflows/validate-multiagent-execution.yml"
   push:
@@ -40,6 +41,7 @@ on:
       - "core/MERGE_TRAIN.md"
       - "docs/MULTIAGENT_IMPLEMENTATION_STATUS.md"
       - "docs/JULES_API_FIRST_PILOT_EVIDENCE.md"
+      - ".github/workflows/live-antigravity-pilot.yml"
       - ".github/workflows/live-opencode-ollama-pilot.yml"
       - ".github/workflows/validate-multiagent-execution.yml"
   workflow_dispatch:

--- a/scripts/provider_worker.py
+++ b/scripts/provider_worker.py
@@ -121,12 +121,15 @@ def _outside_worktree(path: Path, worktree: Path, *, label: str) -> Path:
 def _assert_safe_staged_files(request: ProviderTaskRequest, changed_paths: tuple[str, ...]) -> None:
     root = request.worktree.resolve()
     for relative in changed_paths:
-        candidate = (root / relative).resolve()
+        source = root / relative
+        if source.is_symlink():
+            raise ValueError(f"staged provider output must be a regular file: {relative}")
+        candidate = source.resolve()
         try:
             candidate.relative_to(root)
         except ValueError as error:
             raise ValueError(f"staged path escaped provider worktree: {relative}") from error
-        if candidate.is_symlink() or not candidate.is_file():
+        if not candidate.is_file():
             raise ValueError(f"staged provider output must be a regular file: {relative}")
         size = candidate.stat().st_size
         if size <= 0 or size > MAX_STAGED_FILE_BYTES:

--- a/scripts/provider_worker.py
+++ b/scripts/provider_worker.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import re
@@ -14,16 +15,19 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from engine.provider_runtime import (  # noqa: E402
+    ProviderInvocation,
     ProviderTaskRequest,
     SubprocessRunner,
     execute_provider_task,
     redact_text,
+    utc_now,
 )
 from engine.providers import AntigravityAdapter, OpenCodeOllamaAdapter  # noqa: E402
 
 DEFAULT_OPENCODE_AGENT = "factory-worker"
 AGENT_NAME_PATTERN = re.compile(r"^[A-Za-z0-9._/-]+$")
 TOOL_NAME_PATTERN = re.compile(r"^[a-z][a-z0-9_]*$")
+MAX_STAGED_FILE_BYTES = 64 * 1024
 DEFAULT_OPENCODE_AGENT_PROMPT = """You are a bounded App Factory worker.
 Follow the user task literally and make only the requested scoped change.
 Use only tools currently exposed by the runtime. Do not inspect unrelated files.
@@ -105,6 +109,111 @@ def _prepare_default_opencode_agent(
     return DEFAULT_OPENCODE_AGENT
 
 
+def _outside_worktree(path: Path, worktree: Path, *, label: str) -> Path:
+    resolved = path.expanduser().resolve()
+    try:
+        resolved.relative_to(worktree.resolve())
+    except ValueError:
+        return resolved
+    raise ValueError(f"{label} must be outside the provider worktree")
+
+
+def _assert_safe_staged_files(request: ProviderTaskRequest, changed_paths: tuple[str, ...]) -> None:
+    root = request.worktree.resolve()
+    for relative in changed_paths:
+        candidate = (root / relative).resolve()
+        try:
+            candidate.relative_to(root)
+        except ValueError as error:
+            raise ValueError(f"staged path escaped provider worktree: {relative}") from error
+        if candidate.is_symlink() or not candidate.is_file():
+            raise ValueError(f"staged provider output must be a regular file: {relative}")
+        size = candidate.stat().st_size
+        if size <= 0 or size > MAX_STAGED_FILE_BYTES:
+            raise ValueError(
+                f"staged provider output must be 1..{MAX_STAGED_FILE_BYTES} bytes: {relative}"
+            )
+        try:
+            text = candidate.read_text(encoding="utf-8")
+        except UnicodeDecodeError as error:
+            raise ValueError(f"staged provider output must be UTF-8 text: {relative}") from error
+        if "\x00" in text:
+            raise ValueError(f"staged provider output contains NUL bytes: {relative}")
+        if redact_text(text, limit=len(text) + 1) != text:
+            raise ValueError(f"staged provider output matches a credential pattern: {relative}")
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _stage_provider_result(
+    *,
+    request: ProviderTaskRequest,
+    result: object,
+    runner: SubprocessRunner,
+    bundle_path: Path,
+    record_path: Path,
+) -> dict[str, object]:
+    output = getattr(result, "output", None)
+    evidence = getattr(result, "evidence", None)
+    if output is None or output.status != "success" or evidence is None:
+        detail = getattr(output, "error", None) if output is not None else None
+        raise RuntimeError(detail or "provider did not produce a validated staged commit")
+    if evidence.pushed:
+        raise ValueError("stage-only execution must not publish the worker branch")
+    if not evidence.start_sha or not evidence.commit_sha or not evidence.changed_paths:
+        raise ValueError("stage-only execution did not produce complete local evidence")
+
+    _assert_safe_staged_files(request, tuple(evidence.changed_paths))
+    bundle = _outside_worktree(bundle_path, request.worktree, label="provider bundle")
+    record = _outside_worktree(record_path, request.worktree, label="stage record")
+    if bundle.exists() or record.exists():
+        raise ValueError("stage outputs must not overwrite existing files")
+    bundle.parent.mkdir(parents=True, exist_ok=True)
+    record.parent.mkdir(parents=True, exist_ok=True)
+
+    bundled = runner.run(
+        ProviderInvocation(
+            provider_id="git-runtime",
+            argv=("git", "bundle", "create", str(bundle), request.working_branch),
+            cwd=request.worktree,
+            timeout_seconds=300,
+        )
+    )
+    if bundled.returncode != 0 or not bundle.is_file() or bundle.stat().st_size <= 0:
+        raise RuntimeError(redact_text(bundled.stderr or bundled.stdout or "git bundle failed"))
+
+    payload: dict[str, object] = {
+        "schema_version": 1,
+        "provider": output.provider_id,
+        "run_id": request.run_id,
+        "task_id": request.task_id,
+        "repository": request.repository,
+        "integration_branch": request.integration_branch,
+        "target_branch": request.target_branch,
+        "working_branch": request.working_branch,
+        "declared_paths": list(request.normalized_paths),
+        "start_sha": evidence.start_sha,
+        "commit_sha": evidence.commit_sha,
+        "changed_paths": list(evidence.changed_paths),
+        "bundle_sha256": _sha256_file(bundle),
+        "staged_at": utc_now(),
+        "github_run_id": str(os.environ.get("GITHUB_RUN_ID") or ""),
+        "github_run_attempt": str(os.environ.get("GITHUB_RUN_ATTEMPT") or ""),
+        "github_sha": str(os.environ.get("GITHUB_SHA") or ""),
+    }
+    record.write_text(
+        json.dumps(payload, indent=2, ensure_ascii=False, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return payload
+
+
 def parser() -> argparse.ArgumentParser:
     root = argparse.ArgumentParser(
         description="Safe App Factory local/headless provider worker runtime"
@@ -116,13 +225,14 @@ def parser() -> argparse.ArgumentParser:
     )
     validate.add_argument("spec", type=Path)
 
-    for command in ("probe", "command", "run"):
+    for command in ("probe", "command", "run", "stage"):
         item = sub.add_parser(
             command,
             help={
                 "probe": "Probe provider health without running a task",
                 "command": "Show the redacted fixed-argv invocation for a task",
                 "run": "Execute, validate, commit, and publish a worker branch",
+                "stage": "Execute, validate, commit, and export a credential-free Git bundle",
             }[command],
         )
         item.add_argument(
@@ -139,13 +249,26 @@ def parser() -> argparse.ArgumentParser:
             type=Path,
             help="Dedicated provider profile directory; never use the normal user profile",
         )
-        if command in {"command", "run"}:
+        if command in {"command", "run", "stage"}:
             item.add_argument("spec", type=Path)
         if command == "run":
             item.add_argument(
                 "--publish",
                 action="store_true",
                 help="Required: push the validated worker branch so completion is durable in GitHub",
+            )
+        if command == "stage":
+            item.add_argument(
+                "--bundle",
+                type=Path,
+                required=True,
+                help="Output Git bundle path outside the provider worktree",
+            )
+            item.add_argument(
+                "--record",
+                type=Path,
+                required=True,
+                help="Output sanitized stage-record JSON path outside the provider worktree",
             )
     return root
 
@@ -228,6 +351,17 @@ def main() -> int:
                 "request": request.to_dict(),
                 "invocation": adapter.build_invocation(request).to_dict(),
             })
+            return 0
+        if args.command == "stage":
+            result = execute_provider_task(adapter, request, runner=runner, publish=False)
+            payload = _stage_provider_result(
+                request=request,
+                result=result,
+                runner=runner,
+                bundle_path=args.bundle,
+                record_path=args.record,
+            )
+            emit({"staged": True, "record": payload})
             return 0
         if args.command == "run":
             if not args.publish:

--- a/tests/multiagent/test_provider_worker_cli.py
+++ b/tests/multiagent/test_provider_worker_cli.py
@@ -37,6 +37,48 @@ class ProviderWorkerCliTests(unittest.TestCase):
             "allowed_commands": ["python -m unittest*"],
         }
 
+    @staticmethod
+    def init_repo(worktree: Path, branch: str) -> None:
+        worktree.mkdir()
+        subprocess.run(
+            ["git", "init", "-b", branch], cwd=worktree, check=True, capture_output=True
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "Factory Test"], cwd=worktree, check=True
+        )
+        subprocess.run(
+            ["git", "config", "user.email", "factory-test@example.invalid"],
+            cwd=worktree,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "remote", "add", "origin", "https://github.com/owner/repo.git"],
+            cwd=worktree,
+            check=True,
+        )
+        (worktree / "README.md").write_text("baseline\n", encoding="utf-8")
+        subprocess.run(["git", "add", "README.md"], cwd=worktree, check=True)
+        subprocess.run(
+            ["git", "commit", "-m", "baseline"],
+            cwd=worktree,
+            check=True,
+            capture_output=True,
+        )
+
+    @staticmethod
+    def fake_antigravity(path: Path, *, content: str) -> None:
+        path.write_text(
+            "#!/usr/bin/env python3\n"
+            "import json\n"
+            "from pathlib import Path\n"
+            "target = Path('docs/stage.txt')\n"
+            "target.parent.mkdir(parents=True, exist_ok=True)\n"
+            f"target.write_text({content!r}, encoding='utf-8')\n"
+            "print(json.dumps({'status': 'SUCCESS', 'response': 'done', 'conversation_id': 'fake'}))\n",
+            encoding="utf-8",
+        )
+        path.chmod(0o755)
+
     def test_validate_and_redacted_command_are_machine_readable(self) -> None:
         with tempfile.TemporaryDirectory(prefix="provider-cli-") as raw:
             root = Path(raw)
@@ -89,6 +131,114 @@ class ProviderWorkerCliTests(unittest.TestCase):
             self.assertEqual(result.returncode, 1)
             payload = json.loads(result.stdout)
             self.assertIn("requires --publish", payload["error"])
+
+    def test_stage_creates_sanitized_bundle_without_push(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="provider-cli-stage-") as raw:
+            root = Path(raw)
+            worktree = root / "worktree"
+            profile = root / "profile"
+            profile.mkdir()
+            branch = "factory/cli-provider-worker-a"
+            self.init_repo(worktree, branch)
+            fake = root / "agy"
+            self.fake_antigravity(fake, content="Antigravity staged provider evidence\n")
+
+            request = self.request(worktree)
+            request["working_branch"] = branch
+            request["paths"] = ["docs/stage.txt"]
+            request["allowed_commands"] = []
+            spec = root / "request.json"
+            spec.write_text(json.dumps(request), encoding="utf-8")
+            bundle = root / "stage" / "provider.bundle"
+            record = root / "stage" / "stage-record.json"
+
+            result = self.run_cli(
+                "stage",
+                "--provider",
+                "antigravity",
+                "--binary",
+                str(fake),
+                "--profile-home",
+                str(profile),
+                "--effort",
+                "medium",
+                "--bundle",
+                str(bundle),
+                "--record",
+                str(record),
+                str(spec),
+            )
+            payload = json.loads(result.stdout)
+            stage = json.loads(record.read_text(encoding="utf-8"))
+            self.assertTrue(payload["staged"])
+            self.assertTrue(bundle.is_file())
+            self.assertEqual(stage["provider"], "antigravity")
+            self.assertEqual(stage["working_branch"], branch)
+            self.assertEqual(stage["changed_paths"], ["docs/stage.txt"])
+            self.assertEqual(stage["declared_paths"], ["docs/stage.txt"])
+            self.assertNotIn("instruction", stage)
+            self.assertNotIn("response", stage)
+            self.assertNotIn("session_id", stage)
+            rendered = json.dumps(stage)
+            self.assertNotIn("SENSITIVE TASK INSTRUCTION", rendered)
+            self.assertNotIn(str(profile), rendered)
+            subprocess.run(
+                ["git", "bundle", "verify", str(bundle)],
+                cwd=worktree,
+                check=True,
+                capture_output=True,
+            )
+            remote = subprocess.run(
+                ["git", "ls-remote", "--heads", "origin", branch],
+                cwd=worktree,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(remote.stdout.strip(), "")
+
+    def test_stage_rejects_credential_pattern_before_bundle(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="provider-cli-stage-secret-") as raw:
+            root = Path(raw)
+            worktree = root / "worktree"
+            profile = root / "profile"
+            profile.mkdir()
+            branch = "factory/cli-provider-secret-worker"
+            self.init_repo(worktree, branch)
+            fake = root / "agy"
+            self.fake_antigravity(
+                fake,
+                content="token: ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890\n",
+            )
+
+            request = self.request(worktree)
+            request["working_branch"] = branch
+            request["paths"] = ["docs/stage.txt"]
+            request["allowed_commands"] = []
+            spec = root / "request.json"
+            spec.write_text(json.dumps(request), encoding="utf-8")
+            bundle = root / "stage" / "provider.bundle"
+            record = root / "stage" / "stage-record.json"
+
+            result = self.run_cli(
+                "stage",
+                "--provider",
+                "antigravity",
+                "--binary",
+                str(fake),
+                "--profile-home",
+                str(profile),
+                "--bundle",
+                str(bundle),
+                "--record",
+                str(record),
+                str(spec),
+                check=False,
+            )
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("credential pattern", json.loads(result.stdout)["error"])
+            self.assertFalse(bundle.exists())
+            self.assertFalse(record.exists())
 
     def test_validate_rejects_protected_scope(self) -> None:
         with tempfile.TemporaryDirectory(prefix="provider-cli-scope-") as raw:

--- a/tests/multiagent/test_provider_worker_cli.py
+++ b/tests/multiagent/test_provider_worker_cli.py
@@ -39,6 +39,10 @@ class ProviderWorkerCliTests(unittest.TestCase):
 
     @staticmethod
     def init_repo(worktree: Path, branch: str) -> None:
+        remote = worktree.parent / "remote.git"
+        subprocess.run(
+            ["git", "init", "--bare", str(remote)], check=True, capture_output=True
+        )
         worktree.mkdir()
         subprocess.run(
             ["git", "init", "-b", branch], cwd=worktree, check=True, capture_output=True
@@ -52,7 +56,7 @@ class ProviderWorkerCliTests(unittest.TestCase):
             check=True,
         )
         subprocess.run(
-            ["git", "remote", "add", "origin", "https://github.com/owner/repo.git"],
+            ["git", "remote", "add", "origin", str(remote)],
             cwd=worktree,
             check=True,
         )
@@ -191,7 +195,7 @@ class ProviderWorkerCliTests(unittest.TestCase):
             remote = subprocess.run(
                 ["git", "ls-remote", "--heads", "origin", branch],
                 cwd=worktree,
-                check=False,
+                check=True,
                 capture_output=True,
                 text=True,
             )

--- a/tests/multiagent/test_provider_worker_stage_safety.py
+++ b/tests/multiagent/test_provider_worker_stage_safety.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+from scripts.provider_worker import _assert_safe_staged_files
+
+
+class ProviderWorkerStageSafetyTests(unittest.TestCase):
+    def test_staged_symlink_is_rejected_before_resolution(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="provider-stage-symlink-") as raw:
+            root = Path(raw)
+            docs = root / "docs"
+            docs.mkdir()
+            target = root / "target.txt"
+            target.write_text("safe target\n", encoding="utf-8")
+            symlink = docs / "stage.txt"
+            try:
+                symlink.symlink_to(target)
+            except OSError as error:
+                self.skipTest(f"symlink unavailable on this platform: {error}")
+
+            request = SimpleNamespace(worktree=root)
+            with self.assertRaisesRegex(ValueError, "regular file"):
+                _assert_safe_staged_files(request, ("docs/stage.txt",))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Prepares the Antigravity live homologation without executing it.

Key changes:
- superseding pilot contract is tracked in #115 with non-colliding sibling refs;
- `provider_worker.py stage` executes the existing bounded runtime with `publish=False`, creates the controlled local commit, scans bounded UTF-8 output for credential patterns, and emits only a Git bundle plus sanitized stage record outside the worktree;
- regression tests prove stage-only commit/bundle behavior, no remote push, no raw prompt/session material in the record, and secret-pattern rejection before artifact creation;
- `live-antigravity-pilot.yml` splits execution into a permissions-empty ephemeral self-hosted provider job and a separate GitHub-hosted trusted publisher;
- publisher validates artifact service digest, immutable run context, bundle digest/history, exact one-file scope, regular-file mode, size and credential hygiene before creating any remote ref;
- worker CI and integration CI are exact-SHA workflow_dispatch runs; worker merge targets only the isolated integration branch; final PR is DRAFT and human-only.

This PR does **not** run Antigravity. Issue #115 remains `factory:blocked` until the dedicated ephemeral runner/profile is provisioned. No target merge, production activation, Banco de Notas work or Codex fallback is introduced.