### PR TITLE
ops: add secure Antigravity ephemeral runner bootstrap

### DIFF
--- a/.github/workflows/validate-factory.yml
+++ b/.github/workflows/validate-factory.yml
@@ -22,3 +22,17 @@ jobs:
         run: python scripts/validate_skills.py
       - name: Validate Codex Plugin package
         run: python scripts/validate_plugin.py
+      - name: Validate PowerShell bootstrap syntax
+        shell: pwsh
+        run: |
+          $tokens = $null
+          $errors = $null
+          [System.Management.Automation.Language.Parser]::ParseFile(
+            (Resolve-Path 'scripts/bootstrap-antigravity-runner.ps1'),
+            [ref] $tokens,
+            [ref] $errors
+          ) | Out-Null
+          if ($errors.Count -gt 0) {
+            $errors | ForEach-Object { Write-Error $_.Message }
+            exit 1
+          }

--- a/docs/MULTIAGENT_IMPLEMENTATION_STATUS.md
+++ b/docs/MULTIAGENT_IMPLEMENTATION_STATUS.md
@@ -1,253 +1,254 @@
 # Multiagent Execution — estado de implementação
 
-Atualizado em 27 de agosto de 2026.
+Atualizado em 28 de agosto de 2026.
 
 ## Classificação atual
 
-A App Factory multiagente já possui prova operacional real para os blocos centrais:
+A App Factory multiagente já é operacional com **Jules + OpenCode/Ollama** e possui prova real de:
 
-- fundação provider-neutral;
-- Jules API-first comprovado em execução real;
-- OpenCode/Ollama comprovado e homologado em execução real;
-- Factory Run mista Jules + OpenCode/Ollama comprovada de ponta a ponta;
-- paralelismo real com `max_parallel=2` e task dependente liberada somente depois dos dois merges;
-- protocolo durável baseado em GitHub;
-- takeover entre executores comprovado depois da expiração de lease;
-- branches/PRs isolados, CI por SHA exato e final PR draft/humano;
-- GitHub Actions comprovadamente capaz de criar worker PRs e o PR final draft no repositório consumidor;
-- Semgrep real integrado e fail-closed;
-- CodeRabbit manual acionável, sujeito a rate limit externo;
-- runtime Antigravity implementado/testado, ainda sem piloto live por depender de runner/profile externo;
-- Sonar preparado no Merge Train, mas ainda dependente de configuração real do serviço.
+- execução provider-neutral;
+- paralelismo (`max_parallel=2`);
+- dependências entre tasks;
+- branches e PRs isolados;
+- CI por SHA exato;
+- recuperação após restart;
+- takeover entre executores após expiração de lease;
+- integração automática somente na integration branch;
+- PR final draft e decisão humana no target;
+- criação autônoma de worker PRs e PR final pelo GitHub Actions;
+- Semgrep real e fail-closed;
+- CodeRabbit vinculado ao SHA exato, inclusive no formato real de zero findings;
+- Control Plane confiável executando autoridade a partir de `main` e tratando o worker como dado não confiável.
 
-A visão automática normal já funciona com Jules + OpenCode/Ollama. A declaração de “100% pronta” continua condicionada ao fechamento do Merge Train real com Sonar e à homologação live do Antigravity.
+A visão ampliada ainda não deve ser declarada 100% homologada porque faltam somente duas provas externas:
 
-## Comprovado em execução real
+1. SonarQube Cloud real fechando o Merge Train completo;
+2. Antigravity live em runner Linux x64 efêmero com profile autenticado isolado.
+
+## Provas concluídas
 
 ### Jules API-first
 
-No `mcpmieda/ecossistema-escola`, a Factory Run `jules-api-pilot-002` comprovou:
-
-- materialização durável em GitHub;
-- dispatch Jules por REST API;
-- dois workers paralelos;
-- dependência liberada após merges;
-- branches/PRs isolados;
-- escopo por arquivos;
-- CI obrigatório por `workflow_dispatch` e `head_sha` exato;
-- retomada de task em `factory:ci` após restart;
-- ausência de sessão duplicada;
-- squash merge somente na integration branch;
-- CI final completo;
-- PR final draft e humano.
-
-O PR consolidado `#93` foi posteriormente mesclado por decisão humana. Isso não amplia a autoridade automática da Factory sobre `main`.
+No `mcpmieda/ecossistema-escola`, a Factory Run `jules-api-pilot-002` comprovou duas tasks Jules paralelas, task dependente, branches/PRs isolados, retomada de `factory:ci`, ausência de sessão duplicada, CI exato e PR final humano. O PR consolidado `#93` foi posteriormente mesclado por decisão humana.
 
 ### Takeover entre executores
 
-A issue `#72` (`durable-takeover-proof-001`) comprovou com dois runners GitHub-hosted distintos:
+A issue `mcpmieda/app-factory#72` comprovou:
 
-- fingerprints imutáveis idênticos nos dois executores;
-- Lease A válida somente para executor A;
-- rejeição de B enquanto A mantinha lease ativa;
-- heartbeat sem extensão da expiração;
+- Lease A exclusiva do executor A;
+- rejeição de B enquanto A estava válida;
+- heartbeat sem extensão implícita;
 - expiração real da Lease A;
-- nova Lease B para executor B com as mesmas identidades de run/task/request/manifest/branches;
-- rejeição de A contra Lease B;
-- autorização de B contra Lease B;
-- estado durável vindo de GitHub, não de cache, stdout ou sessão local.
+- Lease B para executor B com os mesmos fingerprints imutáveis;
+- rejeição posterior de A;
+- continuidade baseada em estado durável do GitHub, sem cache/local session.
 
-### OpenCode/Ollama standalone
+### OpenCode/Ollama
 
-A homologação live v16, issue `#110` do `app-factory`, concluiu com sucesso no run `33125439929`.
+A homologação live v16 (`app-factory#110`) concluiu com sucesso:
 
-Evidência principal:
-
-- provider real: OpenCode `1.18.23` + Ollama `0.33.1` + `qwen3:0.6b`;
-- inference real via Ollama native `POST /api/chat`;
-- exatamente um `write` estruturado aceito e encaminhado;
-- audit do bridge sem rejeições/upstream errors;
-- arquivo validado byte a byte contra fixture imutável definida antes da execução;
-- exatamente um path alterado;
-- commit/push controlado e SHA remoto confirmado;
-- CI por `workflow_dispatch` no SHA exato: run `33125552090` — `success`;
-- nenhum merge no target, ativação de produção, ampliação de permissão ou execução Codex.
-
-As versões v13–v15 permanecem como evidência do repair loop fail-closed e nunca foram reclassificadas retroativamente como sucesso.
+- OpenCode `1.18.23`;
+- Ollama `0.33.1`;
+- `qwen3:0.6b`;
+- inferência real via `/api/chat`;
+- exatamente um `write` estruturado;
+- validação byte a byte;
+- um único path alterado;
+- commit/push controlado;
+- SHA remoto confirmado;
+- exact-SHA CI verde;
+- zero Codex, zero merge no target e zero ativação de produção.
 
 ### Factory Run real Jules + OpenCode/Ollama
 
-A homologação final multi-provider foi executada no `mcpmieda/ecossistema-escola` pela parent issue `#112`, run id `multi-provider-hosted-pilot-002`.
-
-Topologia real:
+A run `multi-provider-hosted-pilot-002` no `ecossistema-escola` comprovou:
 
 ```text
-#113 OpenCode/Ollama ─┐
-                     ├─> #115 Jules verifier
-#114 Jules API-first ─┘
+OpenCode/Ollama ─┐
+                 ├─> Jules verifier
+Jules API-first ─┘
 ```
 
-Contrato:
-
 - `max_parallel=2`;
-- OpenCode e Jules independentes liberados simultaneamente;
-- task `verify` bloqueada até os dois resultados estarem materialmente integrados;
-- integração isolada `factory/multi-provider-hosted-pilot-002`;
-- target `main` fora da autoridade automática;
-- produção, Banco de Notas e Codex fora do escopo.
+- workers independentes liberados simultaneamente;
+- verifier bloqueado até os dois resultados estarem integrados;
+- hosted OpenCode e Jules reais;
+- exact-SHA CI por worker;
+- squash somente na integration branch;
+- CI consolidado da integration branch;
+- PR final `#120` criado automaticamente como **DRAFT** para `main`;
+- target merge permanece humano.
 
-Evidência OpenCode `#113`:
+Isso encerra a antiga pendência “provar uma Factory Run com mais de um provider automático”.
 
-- executor GitHub-hosted;
-- probe real saudável;
-- branch durável sibling sem colisão de namespace;
-- lease bot-authored;
-- provider result `success`;
-- commit/push `25adb91a9bfa86c3f60002e78e12976c22f7412e`;
-- exatamente um path alterado;
-- exact-SHA CI `33133753826` — `success`;
-- worker PR `#116` squash-merged somente na integration branch.
-
-Evidência Jules `#114`:
-
-- sessão Jules REST real;
-- worker PR `#117` passou CI obrigatório;
-- squash merge somente na mesma integration branch.
-
-Evidência dependente `#115`:
-
-- permaneceu `waiting` até #113 e #114 estarem integradas;
-- sessão Jules criada somente após a liberação das dependências;
-- worker PR `#119` passou CI obrigatório;
-- merge SHA da integration branch `1de720f36729b0c36b3f459242a6312286d6a92e`.
-
-Fechamento da run:
-
-- job multi-provider `33133633332` concluiu `success`;
-- integration CI final `33134149253` concluiu `success`;
-- o bot criou o PR final `#120`, `factory/multi-provider-hosted-pilot-002 -> main`;
-- PR `#120` permanece **DRAFT**, rotulado `factory:final`;
-- o corpo registra explicitamente que é o human gate e que a Factory não fará o merge no target.
-
-Isto encerra a antiga pendência “provar uma Factory Run com mais de um provider automático”.
-
-## Repair loop do hosted OpenCode no Ecossistema
-
-A prova mista também encontrou e corrigiu, sem relaxar guardrails:
-
-1. **Schema do health probe** — o provider real reportava `provider`, enquanto o executor lia somente `provider_id`. PR `#109` normalizou a fronteira confiável mantendo provider/status estritos.
-2. **Namespace de Git refs** — `factory/<run>` não pode coexistir com `factory/<run>/<task>`. PR `#110` adotou workers sibling `factory/<run>-<task>` com regressão.
-3. **Fixture Markdown da v1** — o provider escreveu o conteúdo pedido, mas Prettier rejeitou apenas newline terminal ausente. O resultado não foi adulterado nem reclassificado; a v2 definiu previamente um fixture `.txt`, fora do domínio do formatter, e passou todos os gates.
-
-## Implementado no Core
+## Runtime e autoridade
 
 ### Planner
 
-- grafo de tarefas e dependências;
+- DAG de tasks/dependências;
 - waves paralelas;
 - serialização por conflito de path;
-- política `zero -> free_quota -> included -> metered`;
-- `max_parallel` obrigatório entre 1 e 3;
+- `max_parallel` entre 1 e 3;
+- política de provider `zero -> free_quota -> included -> metered`;
 - Codex `automatic=false`;
-- human gates;
-- CLI de template, validação, registry e plano.
+- human gates.
 
-### Provider Runtime / Durable Agent
+### Durable provider runtime
 
-- request e manifesto frozen/validados;
+- request/manifesto imutáveis e validados;
 - fingerprint portátil;
-- health `healthy/degraded/unavailable/unknown`;
-- ambiente sanitizado e profiles dedicados;
-- lease vinculada a run/task/issue/provider/executor/branches/hashes;
-- confiança somente em lease bot-authored válida;
+- lease bot-authored ligada a run/task/issue/provider/executor/branches/hashes;
 - expiração/takeover fail-closed;
-- heartbeat sem renovação implícita;
+- heartbeat sem renovar autoridade;
 - resultado terminal vinculado à lease;
-- provider sem autoridade para merge no target;
-- escopo protegido e Git mutável fail-closed;
-- commit/push apenas de worker branch;
+- ambiente sanitizado e profiles dedicados;
+- proteção de paths/Git metadata;
+- commit/push apenas da worker branch;
 - confirmação remota do SHA;
-- telemetria sanitizada.
+- workers sem autoridade sobre target/produção.
 
-### Antigravity
+## Merge Train confiável
 
-O adapter está implementado/testado com CLI headless, profile isolado obrigatório e sem bypass de permissões.
+Contrato vigente no `mcpmieda/ecossistema-escola`:
 
-O piloto live continua materializado na issue `#65`, mas depende de:
+- worker PR aponta somente para uma integration branch Factory;
+- CI obrigatório por SHA exato;
+- Semgrep + Sonar + CodeRabbit precisam validar o mesmo SHA;
+- evidência stale ou ausente falha fechado;
+- autoridade do gate vem de código confiável de `main`;
+- PR final permanece draft/humano;
+- target auto-merge é proibido.
 
-- runner efêmero/fresh Linux x64 dedicado;
-- labels `self-hosted`, `Linux`, `X64`, `factory-antigravity`, `ephemeral`;
-- `agy`, Git e Python instalados;
-- `ANTIGRAVITY_PROFILE_HOME` autenticado e dedicado, fora de qualquer worktree;
-- destruição/reprovisionamento do runner depois da prova.
+### Estado real dos reviewers
 
-A ausência desses pré-requisitos deve continuar falhando fechado.
+**Semgrep**
 
-## Merge Train
+- integrado e executado de verdade;
+- já encontrou findings reais durante o desenvolvimento;
+- repair loop corrigiu as causas sem `nosemgrep`/suppressions;
+- evidence SHA-bound está operacional.
 
-Contrato lógico vigente:
+**CodeRabbit**
 
-- worker PR limitado à integration branch;
-- CI exato por SHA/evento;
-- escopo obrigatório;
-- Semgrep, Sonar e CodeRabbit no mesmo SHA;
-- revisão bloqueadora impede merge;
-- evidência stale é inválida;
-- PR final draft;
-- target auto-merge sempre proibido.
+- integração real comprovada;
+- o gate reconhece review submissions com findings/zero findings;
+- também reconhece o comportamento real em que CodeRabbit atualiza seu comentário `recent_review` sem criar nova review submission quando existem zero actionable comments;
+- essa forma alternativa só é aceita se for bot-authored, contiver a seção limitada `recent_review`, declarar zero actionable comments e terminar no SHA exato esperado;
+- skip, indisponibilidade, rate limit, SHA errado e findings continuam falhando fechado.
 
-Estado real:
+**SonarQube Cloud**
 
-- **Semgrep**: real, integrado, já encontrou findings reais e comprovou repair loop;
-- **CodeRabbit**: comando manual funciona, mas o serviço pode responder `rate limited`; isso deve falhar fechado;
-- **Sonar**: workflow fail-closed preparado, ainda precisa das credenciais/configuração reais do serviço;
-- **Control Plane consumidor**: hardening do gate confiável está sendo fechado no PR `mcpmieda/ecossistema-escola#118`, após o CodeRabbit ter corretamente rejeitado o desenho anterior em que o worker executava o código de sua própria aprovação.
+A infraestrutura confiável foi concluída no `ecossistema-escola`:
 
-O desenho seguro do PR `#118` move a autoridade para código de `main`, usa reviewer evidence bot-authored por SHA e trata o worker como dado não confiável.
+- PR `#132` foi mesclado no commit `52beeaace9a4ee673c057bdc25f78c791e94e32c`;
+- `infra/factory/configure-sonar-merge-train.ps1` automatiza criação/validação do projeto, repository variables, secret, baseline de `main`, Sonar do worker e o CI final da Factory;
+- `sonar-main-baseline.yml` fixa a primeira análise em um SHA atual de `main`;
+- `merge-train-sonar.yml` valida o worker SHA real e usa a baseline estável de `main`;
+- SonarScanner CLI é pinado por versão e SHA-256;
+- PowerShell, actionlint, policy, zizmor, Semgrep e CI geral ficaram verdes antes do merge.
 
-## Dependências externas restantes
+A única dependência Sonar restante é externa: existir uma organização SonarQube Cloud e um token válido. O token nunca deve ir para issue, workflow input ou chat.
 
-### Antigravity
+Execução prevista no repositório consumidor:
 
-Runner/profile descritos na issue `#65`. Credenciais nunca devem ir para issue, workflow input ou chat.
+```powershell
+pwsh ./infra/factory/configure-sonar-merge-train.ps1 -Organization '<SONAR_ORG>'
+```
 
-### Sonar
+O script solicita `SONAR_TOKEN` de forma não exibida e executa as provas restantes. Se o serviço/plano não suportar a análise exigida, o gate deve continuar falhando fechado.
 
-O repositório consumidor precisa de configuração real de SonarQube Cloud:
+## Antigravity
 
-- repository variable `SONAR_PROJECT_KEY`;
-- repository variable `SONAR_ORGANIZATION`;
-- repository secret `SONAR_TOKEN`.
+O adapter e o fluxo live estão implementados/testados. A prova canônica é `app-factory#115` (`antigravity-live-pilot-002`); a antiga issue `#65` foi superseded porque o par original de refs colidia no namespace Git.
 
-O gate deve falhar, e não pular Sonar, enquanto esses valores não existirem.
+### Workflow live preparado
 
-### CodeRabbit
+`.github/workflows/live-antigravity-pilot.yml` separa credenciais em dois estágios:
 
-O mecanismo manual foi comprovado, mas disponibilidade/rate limit é controlada pelo serviço externo. O gate não deve fabricar sucesso quando o reviewer estiver indisponível.
+**Provider stage — self-hosted efêmero**
+
+- labels obrigatórias `self-hosted`, `Linux`, `X64`, `factory-antigravity`, `ephemeral`;
+- job permissions `{}`;
+- checkout público sem credential helper;
+- `GITHUB_TOKEN`, `GH_TOKEN` e `FACTORY_GITHUB_TOKEN` proibidos no ambiente do provider;
+- `ANTIGRAVITY_PROFILE_HOME` autenticado, dedicado e fora do worktree;
+- `agy` roda pelo provider runtime bounded;
+- nenhuma publicação GitHub;
+- artifact contém somente `provider.bundle` + `stage-record.json` sanitizado.
+
+**Trusted publisher — GitHub-hosted**
+
+- começa somente depois do provider terminar;
+- confere digest, contexto, histórico, ancestry, path scope e credential patterns;
+- cria refs isoladas somente após validação;
+- publica worker commit;
+- exact-SHA CI do worker;
+- squash somente na integration branch;
+- exact-SHA CI da integration branch;
+- cria PR final **DRAFT** para `main`;
+- para antes de qualquer merge no target ou produção.
+
+### Bootstrap PowerShell do runner
+
+Este estado adiciona `scripts/bootstrap-antigravity-runner.ps1`, feito para um host/VM/WSL Linux x64 dedicado e descartável. O script:
+
+- rejeita root, plataforma/arquitetura erradas e homes com credenciais GitHub persistentes conhecidas;
+- exige `ptrace_scope >= 1` quando Yama está disponível;
+- valida `agy`, Git e Python;
+- cria/valida profile Antigravity isolado e `chmod 700`;
+- pode abrir o login interativo do `agy` somente no profile dedicado;
+- autentica `gh` em `GH_CONFIG_DIR` temporário;
+- registra runner **ephemeral** com labels obrigatórias;
+- usa GitHub Actions runner oficial `v2.337.0` pinado por SHA-256 `70920811a4f8ad4328818682bca5c6469c1c942fab52448868071d0063816613`;
+- recusa runner `factory-antigravity` concorrente/stale;
+- grava somente a variável `ANTIGRAVITY_PROFILE_HOME` no repositório;
+- dispara `/run-antigravity-v2` somente quando solicitado;
+- destrói a credencial temporária do GitHub **antes** de iniciar o runner/provider;
+- inicia o runner com HOME/XDG temporários e sem tokens GitHub do bootstrap;
+- espera apenas o provider-stage efêmero;
+- depois disso o publisher continua duravelmente no GitHub-hosted runner;
+- restaura o shell local e remove o diretório temporário do runner no cleanup.
+
+A CI `validate-factory.yml` valida a sintaxe desse PowerShell com o parser real do `pwsh`, mas não executa o bootstrap nem cria runner durante CI.
+
+### Dependência externa ainda necessária
+
+O piloto live continua dependendo de um host Linux x64 realmente disponível e de login interativo do Antigravity. Isso não pode ser fabricado pelo GitHub-hosted Control Plane sem quebrar a separação de credenciais.
+
+No host dedicado, a execução prevista é:
+
+```powershell
+pwsh ./scripts/bootstrap-antigravity-runner.ps1 -AuthenticateProfile -RunPilot
+```
+
+O usuário conclui apenas os logins interativos. Depois que o provider-stage termina, o computador local deixa de ser necessário e o publisher segue pelo GitHub.
 
 ## Dependências que NÃO são mais bloqueadores
 
-A antiga documentação dizia que GitHub Actions não podia criar/aprovar PRs. Essa afirmação não é mais válida para a criação de PRs:
-
-- hosted OpenCode criou worker PR `#116`;
-- Jules criou worker PRs `#117` e `#119`;
-- o bot criou o PR final draft `#120`.
-
-Portanto, criação autônoma de PR está comprovadamente habilitada. O **merge final em `main` continua humano por design**, não por limitação administrativa.
+- criação autônoma de worker PRs;
+- criação do PR final draft;
+- Jules live;
+- OpenCode/Ollama live;
+- paralelismo multi-provider;
+- recovery/restart;
+- cross-executor takeover;
+- Semgrep real;
+- hardening confiável do Merge Train (`ecossistema-escola#118` mesclado);
+- comportamento CodeRabbit zero-findings (`ecossistema-escola#131` mesclado);
+- infraestrutura Sonar/PowerShell (`ecossistema-escola#132` mesclado).
 
 ## Ainda não homologado live
 
-1. Antigravity executando uma task real no runner/profile isolado exigido.
-2. Sonar fornecendo evidence real no Merge Train.
-3. Merge Train completo Semgrep + Sonar + CodeRabbit passando em um worker real depois do hardening confiável do Control Plane.
+1. SonarQube Cloud fornecendo evidence real e o Merge Train completo Semgrep + Sonar + CodeRabbit passando no worker #126 (ou novo head equivalente).
+2. Antigravity executando a task real de `app-factory#115` no runner/profile isolado exigido.
 
-O piloto multi-provider já não pertence a esta lista: está concluído.
+Esses são bloqueios externos de homologação, não lacunas fundamentais da arquitetura.
 
 ## Regra de declaração
 
 - **Implementado**: código e testes existem.
 - **Comprovado**: passou em execução real com evidência durável.
 - **Homologado**: passou no contrato live definido, com CI e guardrails preservados.
-- **Pronto**: todos os providers/gates considerados obrigatórios para a visão completa estão homologados e dependências externas resolvidas.
+- **Pronto**: todos os providers/gates obrigatórios da visão ampliada estão homologados; o merge final no target continua humano por design.
 
-Hoje a Factory é operacional com **Jules + OpenCode/Ollama**, inclusive em uma mesma run durável com paralelismo, dependências, recovery, CI por SHA exato e PR final humano. O que impede a declaração de 100% da visão ampliada está concentrado em **Antigravity live + Sonar real + fechamento do Merge Train completo**.
+Hoje a Factory é operacional com **Jules + OpenCode/Ollama**. Para declarar a visão ampliada 100% homologada faltam apenas **Sonar real + Antigravity live**.

--- a/scripts/bootstrap-antigravity-runner.ps1
+++ b/scripts/bootstrap-antigravity-runner.ps1
@@ -1,0 +1,514 @@
+[CmdletBinding()]
+param(
+    [ValidateNotNullOrEmpty()]
+    [string] $Repository = 'mcpmieda/app-factory',
+
+    [ValidateRange(1, 2147483647)]
+    [int] $PilotIssue = 115,
+
+    [ValidateNotNullOrEmpty()]
+    [string] $ProfileHome = "$HOME/.factory-antigravity-profile",
+
+    [ValidateNotNullOrEmpty()]
+    [string] $RunnerRoot = "$HOME/.factory-antigravity-runners",
+
+    [ValidateNotNullOrEmpty()]
+    [string] $RunnerVersion = '2.337.0',
+
+    [ValidatePattern('^[0-9a-f]{64}$')]
+    [string] $RunnerSha256 = '70920811a4f8ad4328818682bca5c6469c1c942fab52448868071d0063816613',
+
+    [switch] $AuthenticateProfile,
+
+    [switch] $RunPilot,
+
+    [ValidateRange(5, 60)]
+    [int] $RegistrationTimeoutMinutes = 10,
+
+    [ValidateRange(10, 90)]
+    [int] $ProviderStageTimeoutMinutes = 55
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$requiredLabels = @('self-hosted', 'Linux', 'X64', 'factory-antigravity', 'ephemeral')
+$sensitiveEnvironmentNames = @('GITHUB_TOKEN', 'GH_TOKEN', 'FACTORY_GITHUB_TOKEN')
+$profileEnvironmentNames = @(
+    'HOME',
+    'USERPROFILE',
+    'APPDATA',
+    'LOCALAPPDATA',
+    'XDG_CONFIG_HOME',
+    'XDG_DATA_HOME',
+    'XDG_CACHE_HOME',
+    'XDG_STATE_HOME'
+)
+
+function Assert-Command {
+    param([Parameter(Mandatory)][string] $Name)
+
+    if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
+        throw "Comando obrigatório não encontrado: $Name"
+    }
+}
+
+function Invoke-Gh {
+    param([Parameter(Mandatory)][string[]] $Arguments)
+
+    $output = @(& gh @Arguments 2>&1)
+    if ($LASTEXITCODE -ne 0) {
+        throw ($output -join [Environment]::NewLine)
+    }
+    return $output
+}
+
+function Test-PathInside {
+    param(
+        [Parameter(Mandatory)][string] $Child,
+        [Parameter(Mandatory)][string] $Parent
+    )
+
+    $relative = [IO.Path]::GetRelativePath($Parent, $Child)
+    return $relative -eq '.' -or (-not $relative.StartsWith("..$([IO.Path]::DirectorySeparatorChar)"))
+}
+
+function Invoke-WithAntigravityProfile {
+    param(
+        [Parameter(Mandatory)][string] $Profile,
+        [Parameter(Mandatory)][scriptblock] $Action
+    )
+
+    $saved = @{}
+    foreach ($name in $profileEnvironmentNames) {
+        $saved[$name] = [Environment]::GetEnvironmentVariable($name, 'Process')
+    }
+
+    try {
+        $env:HOME = $Profile
+        $env:USERPROFILE = $Profile
+        $env:APPDATA = Join-Path $Profile 'AppData/Roaming'
+        $env:LOCALAPPDATA = Join-Path $Profile 'AppData/Local'
+        $env:XDG_CONFIG_HOME = Join-Path $Profile 'xdg/config'
+        $env:XDG_DATA_HOME = Join-Path $Profile 'xdg/data'
+        $env:XDG_CACHE_HOME = Join-Path $Profile 'xdg/cache'
+        $env:XDG_STATE_HOME = Join-Path $Profile 'xdg/state'
+
+        foreach ($path in @(
+                $env:APPDATA,
+                $env:LOCALAPPDATA,
+                $env:XDG_CONFIG_HOME,
+                $env:XDG_DATA_HOME,
+                $env:XDG_CACHE_HOME,
+                $env:XDG_STATE_HOME
+            )) {
+            New-Item -ItemType Directory -Force -Path $path | Out-Null
+        }
+
+        & $Action
+    }
+    finally {
+        foreach ($name in $profileEnvironmentNames) {
+            [Environment]::SetEnvironmentVariable($name, $saved[$name], 'Process')
+        }
+    }
+}
+
+function Assert-AntigravityProfile {
+    param(
+        [Parameter(Mandatory)][string] $Profile,
+        [switch] $AllowInteractiveAuthentication
+    )
+
+    $profileItem = Get-Item -LiteralPath $Profile
+    if ($profileItem.LinkType) {
+        throw 'ANTIGRAVITY_PROFILE_HOME não pode ser symlink.'
+    }
+
+    & chmod 700 -- $Profile
+    if ($LASTEXITCODE -ne 0) {
+        throw 'Não foi possível restringir ANTIGRAVITY_PROFILE_HOME para modo 0700.'
+    }
+
+    foreach ($relative in @('.git-credentials', '.netrc', '.config/gh/hosts.yml')) {
+        $candidate = Join-Path $Profile $relative
+        if (Test-Path -LiteralPath $candidate) {
+            throw "Credencial GitHub/publicação proibida dentro do profile Antigravity: $relative"
+        }
+    }
+
+    Invoke-WithAntigravityProfile -Profile $Profile -Action {
+        & agy --version
+        if ($LASTEXITCODE -ne 0) {
+            throw 'agy --version falhou dentro do profile isolado.'
+        }
+
+        & agy models *> $null
+        if ($LASTEXITCODE -ne 0) {
+            if (-not $AllowInteractiveAuthentication) {
+                throw 'Antigravity ainda não está autenticado neste profile. Reexecute com -AuthenticateProfile.'
+            }
+
+            Write-Host ''
+            Write-Host 'Abrindo Antigravity no profile isolado para autenticação.'
+            Write-Host 'Conclua o login no navegador/fluxo remoto e saia do agy quando a sessão estiver pronta.'
+            & agy
+            if ($LASTEXITCODE -ne 0) {
+                throw 'Sessão interativa do Antigravity terminou com erro.'
+            }
+
+            & agy models *> $null
+            if ($LASTEXITCODE -ne 0) {
+                throw 'Antigravity continua sem model discovery após autenticação.'
+            }
+        }
+    }
+}
+
+function Assert-CredentialFreeHostHome {
+    param([Parameter(Mandatory)][string] $OriginalHome)
+
+    foreach ($relative in @('.git-credentials', '.netrc', '.config/gh/hosts.yml')) {
+        $candidate = Join-Path $OriginalHome $relative
+        if (Test-Path -LiteralPath $candidate) {
+            throw "O host não está limpo para o provider: $candidate existe. Use um usuário/VM/WSL descartável sem credenciais GitHub persistentes."
+        }
+    }
+
+    $ptracePath = '/proc/sys/kernel/yama/ptrace_scope'
+    if (Test-Path -LiteralPath $ptracePath) {
+        $ptraceScope = [int](Get-Content -Raw -LiteralPath $ptracePath).Trim()
+        if ($ptraceScope -lt 1) {
+            throw 'kernel.yama.ptrace_scope precisa ser >= 1 para impedir que um processo filho inspecione a memória do bootstrap.'
+        }
+    }
+}
+
+function Get-RepositoryRunners {
+    param([Parameter(Mandatory)][string] $Repo)
+
+    $json = Invoke-Gh -Arguments @('api', "repos/$Repo/actions/runners?per_page=100")
+    $payload = $json -join [Environment]::NewLine | ConvertFrom-Json
+    return @($payload.runners)
+}
+
+function Get-PilotWorkflowRun {
+    param(
+        [Parameter(Mandatory)][string] $Repo,
+        [Parameter(Mandatory)][DateTimeOffset] $NotBefore
+    )
+
+    for ($attempt = 0; $attempt -lt 20; $attempt += 1) {
+        Start-Sleep -Seconds 2
+        $json = Invoke-Gh -Arguments @(
+            'run', 'list',
+            '--repo', $Repo,
+            '--workflow', 'live-antigravity-pilot.yml',
+            '--event', 'issue_comment',
+            '--limit', '20',
+            '--json', 'databaseId,createdAt,status,conclusion,url'
+        )
+        $runs = @($json -join [Environment]::NewLine | ConvertFrom-Json)
+        $match = $runs |
+            Where-Object { [DateTimeOffset]$_.createdAt -ge $NotBefore } |
+            Sort-Object -Property createdAt -Descending |
+            Select-Object -First 1
+        if ($match) {
+            return $match
+        }
+    }
+
+    throw 'O comentário de trigger foi enviado, mas o workflow Antigravity correspondente não foi localizado.'
+}
+
+function Get-PublicWorkflowJobs {
+    param(
+        [Parameter(Mandatory)][string] $Repo,
+        [Parameter(Mandatory)][long] $RunId
+    )
+
+    $headers = @{
+        Accept = 'application/vnd.github+json'
+        'User-Agent' = 'app-factory-antigravity-bootstrap'
+        'X-GitHub-Api-Version' = '2022-11-28'
+    }
+    return Invoke-RestMethod -Method Get -Uri "https://api.github.com/repos/$Repo/actions/runs/$RunId/jobs?per_page=100" -Headers $headers
+}
+
+if (-not $IsLinux) {
+    throw 'Este bootstrap precisa rodar em Linux x64. Use uma VM/host Linux descartável ou uma distribuição WSL dedicada.'
+}
+
+$architecture = [Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString()
+if ($architecture -ne 'X64') {
+    throw "Arquitetura não suportada para este piloto: $architecture. Esperado: X64."
+}
+
+Assert-Command -Name 'gh'
+Assert-Command -Name 'git'
+Assert-Command -Name 'python3'
+Assert-Command -Name 'curl'
+Assert-Command -Name 'tar'
+Assert-Command -Name 'agy'
+Assert-Command -Name 'id'
+Assert-Command -Name 'chmod'
+
+$userId = (& id -u).Trim()
+if ($userId -eq '0') {
+    throw 'Não execute o runner Antigravity como root.'
+}
+
+$originalHome = [IO.Path]::GetFullPath($HOME)
+Assert-CredentialFreeHostHome -OriginalHome $originalHome
+
+New-Item -ItemType Directory -Force -Path $ProfileHome | Out-Null
+$resolvedProfile = (Resolve-Path -LiteralPath $ProfileHome).Path
+New-Item -ItemType Directory -Force -Path $RunnerRoot | Out-Null
+$resolvedRunnerRoot = (Resolve-Path -LiteralPath $RunnerRoot).Path
+
+if (Test-PathInside -Child $resolvedProfile -Parent $resolvedRunnerRoot) {
+    throw 'ANTIGRAVITY_PROFILE_HOME precisa ficar fora do diretório dos runners efêmeros.'
+}
+
+Assert-AntigravityProfile -Profile $resolvedProfile -AllowInteractiveAuthentication:$AuthenticateProfile
+
+$sessionId = [Guid]::NewGuid().ToString('N')
+$sessionRoot = Join-Path $resolvedRunnerRoot "runner-$sessionId"
+$bootstrapGhDir = Join-Path $sessionRoot 'bootstrap-gh'
+$runnerHome = Join-Path $sessionRoot 'runner-home'
+$archivePath = Join-Path $sessionRoot "actions-runner-linux-x64-$RunnerVersion.tar.gz"
+$runnerName = "factory-antigravity-$([Environment]::MachineName.ToLowerInvariant())-$($sessionId.Substring(0, 8))"
+$runnerProcess = $null
+$removeToken = $null
+$savedSensitiveEnvironment = @{}
+$savedGhConfigDir = $env:GH_CONFIG_DIR
+
+foreach ($name in $sensitiveEnvironmentNames) {
+    $savedSensitiveEnvironment[$name] = [Environment]::GetEnvironmentVariable($name, 'Process')
+    [Environment]::SetEnvironmentVariable($name, $null, 'Process')
+}
+
+try {
+    New-Item -ItemType Directory -Force -Path $sessionRoot, $bootstrapGhDir, $runnerHome | Out-Null
+    & chmod 700 -- $sessionRoot $bootstrapGhDir $runnerHome
+    if ($LASTEXITCODE -ne 0) {
+        throw 'Não foi possível restringir os diretórios temporários do runner.'
+    }
+
+    $env:GH_CONFIG_DIR = $bootstrapGhDir
+    Write-Host 'Autentique o GitHub CLI neste profile temporário. Essa credencial será destruída antes do provider iniciar.'
+    & gh auth login --hostname github.com --git-protocol https --web
+    if ($LASTEXITCODE -ne 0) {
+        throw 'gh auth login falhou.'
+    }
+    Invoke-Gh -Arguments @('auth', 'status', '--hostname', 'github.com') | Out-Null
+
+    $repoParts = $Repository -split '/', 2
+    if ($repoParts.Count -ne 2) {
+        throw 'Repository deve estar no formato owner/repo.'
+    }
+    $repoOwner = $repoParts[0]
+
+    $repoJson = Invoke-Gh -Arguments @('api', "repos/$Repository")
+    $repo = $repoJson -join [Environment]::NewLine | ConvertFrom-Json
+    if ($repo.full_name -ne $Repository) {
+        throw 'O GitHub CLI autenticado não resolveu o repositório esperado.'
+    }
+    if ($repo.owner.login -ne $repoOwner) {
+        throw 'Owner do repositório diverge do contrato do bootstrap.'
+    }
+
+    $existingRunners = Get-RepositoryRunners -Repo $Repository
+    $conflicting = @($existingRunners | Where-Object {
+            @($_.labels.name) -contains 'factory-antigravity'
+        })
+    if ($conflicting.Count -gt 0) {
+        $names = ($conflicting.name -join ', ')
+        throw "Já existe runner com label factory-antigravity: $names. Remova/reprove antes de criar outro."
+    }
+
+    Invoke-Gh -Arguments @(
+        'variable', 'set', 'ANTIGRAVITY_PROFILE_HOME',
+        '--repo', $Repository,
+        '--body', $resolvedProfile
+    ) | Out-Null
+
+    $registrationToken = (Invoke-Gh -Arguments @(
+            'api', '-X', 'POST', "repos/$Repository/actions/runners/registration-token",
+            '--jq', '.token'
+        ) | Select-Object -First 1).Trim()
+    $removeToken = (Invoke-Gh -Arguments @(
+            'api', '-X', 'POST', "repos/$Repository/actions/runners/remove-token",
+            '--jq', '.token'
+        ) | Select-Object -First 1).Trim()
+
+    if ([string]::IsNullOrWhiteSpace($registrationToken) -or [string]::IsNullOrWhiteSpace($removeToken)) {
+        throw 'GitHub não retornou tokens efêmeros de registro/remoção do runner.'
+    }
+
+    $runnerUrl = "https://github.com/actions/runner/releases/download/v$RunnerVersion/actions-runner-linux-x64-$RunnerVersion.tar.gz"
+    Write-Host "Baixando GitHub Actions runner pinado v$RunnerVersion..."
+    Invoke-WebRequest -Uri $runnerUrl -OutFile $archivePath
+    $actualSha = (Get-FileHash -Algorithm SHA256 -LiteralPath $archivePath).Hash.ToLowerInvariant()
+    if ($actualSha -ne $RunnerSha256) {
+        throw "SHA-256 do runner inválido. Esperado $RunnerSha256; recebido $actualSha."
+    }
+
+    & tar -xzf $archivePath -C $sessionRoot
+    if ($LASTEXITCODE -ne 0) {
+        throw 'Falha ao extrair o GitHub Actions runner.'
+    }
+
+    $configScript = Join-Path $sessionRoot 'config.sh'
+    $runScript = Join-Path $sessionRoot 'run.sh'
+    & chmod +x -- $configScript $runScript
+    if ($LASTEXITCODE -ne 0) {
+        throw 'Falha ao tornar scripts oficiais do runner executáveis.'
+    }
+
+    Push-Location $sessionRoot
+    try {
+        & $configScript \
+            --unattended \
+            --ephemeral \
+            --disableupdate \
+            --url "https://github.com/$Repository" \
+            --token $registrationToken \
+            --name $runnerName \
+            --labels 'factory-antigravity,ephemeral' \
+            --work '_work'
+        if ($LASTEXITCODE -ne 0) {
+            throw 'config.sh falhou ao registrar o runner efêmero.'
+        }
+    }
+    finally {
+        Pop-Location
+        $registrationToken = $null
+    }
+
+    $registered = $null
+    $deadline = [DateTimeOffset]::UtcNow.AddMinutes($RegistrationTimeoutMinutes)
+    while ([DateTimeOffset]::UtcNow -lt $deadline -and $null -eq $registered) {
+        Start-Sleep -Seconds 2
+        $registered = Get-RepositoryRunners -Repo $Repository |
+            Where-Object { $_.name -eq $runnerName } |
+            Select-Object -First 1
+    }
+    if ($null -eq $registered) {
+        throw "Runner '$runnerName' não apareceu no repositório dentro do prazo."
+    }
+
+    $labelNames = @($registered.labels.name)
+    foreach ($label in $requiredLabels) {
+        if ($labelNames -notcontains $label) {
+            throw "Runner '$runnerName' não possui label obrigatória: $label"
+        }
+    }
+
+    if (-not $RunPilot) {
+        throw 'Runner/profile validados. Reexecute com -RunPilot para disparar a prova live; o runner temporário desta validação será removido agora.'
+    }
+
+    $triggerAt = [DateTimeOffset]::UtcNow.AddSeconds(-3)
+    Invoke-Gh -Arguments @(
+        'issue', 'comment', [string]$PilotIssue,
+        '--repo', $Repository,
+        '--body', '/run-antigravity-v2'
+    ) | Out-Null
+    $workflowRun = Get-PilotWorkflowRun -Repo $Repository -NotBefore $triggerAt
+    $workflowRunId = [long]$workflowRun.databaseId
+    $workflowUrl = "https://github.com/$Repository/actions/runs/$workflowRunId"
+    Write-Host "Piloto materializado no GitHub: $workflowUrl"
+
+    Remove-Item -Recurse -Force -LiteralPath $bootstrapGhDir
+    $env:GH_CONFIG_DIR = $null
+    foreach ($name in $sensitiveEnvironmentNames) {
+        [Environment]::SetEnvironmentVariable($name, $null, 'Process')
+    }
+
+    if (Test-Path -LiteralPath $bootstrapGhDir) {
+        throw 'Credencial bootstrap do GitHub ainda existe; provider não será iniciado.'
+    }
+
+    foreach ($name in $sensitiveEnvironmentNames) {
+        if ([Environment]::GetEnvironmentVariable($name, 'Process')) {
+            throw "Variável de credencial proibida ainda existe antes do provider: $name"
+        }
+    }
+
+    $env:HOME = $runnerHome
+    $env:USERPROFILE = $runnerHome
+    $env:XDG_CONFIG_HOME = Join-Path $runnerHome 'xdg/config'
+    New-Item -ItemType Directory -Force -Path $env:XDG_CONFIG_HOME | Out-Null
+
+    Write-Host "Iniciando runner efêmero '$runnerName' sem credencial GitHub de bootstrap..."
+    $runnerProcess = Start-Process -FilePath $runScript -WorkingDirectory $sessionRoot -PassThru -NoNewWindow
+
+    try {
+        Wait-Process -Id $runnerProcess.Id -Timeout ($ProviderStageTimeoutMinutes * 60) -ErrorAction Stop
+    }
+    catch {
+        if (-not $runnerProcess.HasExited) {
+            Stop-Process -Id $runnerProcess.Id -Force
+        }
+        throw "Runner não encerrou como efêmero dentro de $ProviderStageTimeoutMinutes minuto(s)."
+    }
+
+    $jobs = $null
+    for ($attempt = 0; $attempt -lt 6; $attempt += 1) {
+        try {
+            $jobs = Get-PublicWorkflowJobs -Repo $Repository -RunId $workflowRunId
+            $providerJob = @($jobs.jobs | Where-Object { $_.name -eq 'Stage Antigravity result without publication credentials' }) | Select-Object -First 1
+            if ($providerJob -and $providerJob.status -eq 'completed') {
+                break
+            }
+        }
+        catch {
+            $jobs = $null
+        }
+        Start-Sleep -Seconds 5
+    }
+
+    if ($null -eq $jobs) {
+        Write-Warning "Runner efêmero encerrou. Não foi possível consultar o job público imediatamente; acompanhe $workflowUrl"
+    }
+    else {
+        $providerJob = @($jobs.jobs | Where-Object { $_.name -eq 'Stage Antigravity result without publication credentials' }) | Select-Object -First 1
+        if ($providerJob -and $providerJob.status -eq 'completed' -and $providerJob.conclusion -ne 'success') {
+            throw "Provider-stage Antigravity terminou com '$($providerJob.conclusion)'. Consulte $workflowUrl"
+        }
+    }
+
+    Write-Host ''
+    Write-Host 'Provider-stage terminou e o computador local já não é necessário.'
+    Write-Host "O publisher GitHub-hosted continuará duravelmente em: $workflowUrl"
+}
+finally {
+    if ($runnerProcess -and -not $runnerProcess.HasExited) {
+        Stop-Process -Id $runnerProcess.Id -Force -ErrorAction SilentlyContinue
+    }
+
+    if ($removeToken -and (Test-Path -LiteralPath (Join-Path $sessionRoot 'config.sh'))) {
+        Push-Location $sessionRoot
+        try {
+            & (Join-Path $sessionRoot 'config.sh') remove --token $removeToken *> $null
+        }
+        catch {
+            Write-Warning 'O cleanup remoto do registro do runner não respondeu; o registro efêmero também é removido pelo GitHub após o job.'
+        }
+        finally {
+            Pop-Location
+        }
+    }
+
+    $removeToken = $null
+    $env:GH_CONFIG_DIR = $savedGhConfigDir
+
+    foreach ($name in $sensitiveEnvironmentNames) {
+        [Environment]::SetEnvironmentVariable($name, $savedSensitiveEnvironment[$name], 'Process')
+    }
+
+    if (Test-Path -LiteralPath $sessionRoot) {
+        Remove-Item -Recurse -Force -LiteralPath $sessionRoot
+    }
+}

--- a/scripts/bootstrap-antigravity-runner.ps1
+++ b/scripts/bootstrap-antigravity-runner.ps1
@@ -281,11 +281,15 @@ $runnerName = "factory-antigravity-$([Environment]::MachineName.ToLowerInvariant
 $runnerProcess = $null
 $removeToken = $null
 $savedSensitiveEnvironment = @{}
+$savedRunnerEnvironment = @{}
 $savedGhConfigDir = $env:GH_CONFIG_DIR
 
 foreach ($name in $sensitiveEnvironmentNames) {
     $savedSensitiveEnvironment[$name] = [Environment]::GetEnvironmentVariable($name, 'Process')
     [Environment]::SetEnvironmentVariable($name, $null, 'Process')
+}
+foreach ($name in $profileEnvironmentNames) {
+    $savedRunnerEnvironment[$name] = [Environment]::GetEnvironmentVariable($name, 'Process')
 }
 
 try {
@@ -366,17 +370,19 @@ try {
         throw 'Falha ao tornar scripts oficiais do runner executáveis.'
     }
 
+    $configArguments = @(
+        '--unattended',
+        '--ephemeral',
+        '--disableupdate',
+        '--url', "https://github.com/$Repository",
+        '--token', $registrationToken,
+        '--name', $runnerName,
+        '--labels', 'factory-antigravity,ephemeral',
+        '--work', '_work'
+    )
     Push-Location $sessionRoot
     try {
-        & $configScript \
-            --unattended \
-            --ephemeral \
-            --disableupdate \
-            --url "https://github.com/$Repository" \
-            --token $registrationToken \
-            --name $runnerName \
-            --labels 'factory-antigravity,ephemeral' \
-            --work '_work'
+        & $configScript @configArguments
         if ($LASTEXITCODE -ne 0) {
             throw 'config.sh falhou ao registrar o runner efêmero.'
         }
@@ -384,6 +390,7 @@ try {
     finally {
         Pop-Location
         $registrationToken = $null
+        $configArguments = $null
     }
 
     $registered = $null
@@ -438,8 +445,22 @@ try {
 
     $env:HOME = $runnerHome
     $env:USERPROFILE = $runnerHome
+    $env:APPDATA = Join-Path $runnerHome 'AppData/Roaming'
+    $env:LOCALAPPDATA = Join-Path $runnerHome 'AppData/Local'
     $env:XDG_CONFIG_HOME = Join-Path $runnerHome 'xdg/config'
-    New-Item -ItemType Directory -Force -Path $env:XDG_CONFIG_HOME | Out-Null
+    $env:XDG_DATA_HOME = Join-Path $runnerHome 'xdg/data'
+    $env:XDG_CACHE_HOME = Join-Path $runnerHome 'xdg/cache'
+    $env:XDG_STATE_HOME = Join-Path $runnerHome 'xdg/state'
+    foreach ($path in @(
+            $env:APPDATA,
+            $env:LOCALAPPDATA,
+            $env:XDG_CONFIG_HOME,
+            $env:XDG_DATA_HOME,
+            $env:XDG_CACHE_HOME,
+            $env:XDG_STATE_HOME
+        )) {
+        New-Item -ItemType Directory -Force -Path $path | Out-Null
+    }
 
     Write-Host "Iniciando runner efêmero '$runnerName' sem credencial GitHub de bootstrap..."
     $runnerProcess = Start-Process -FilePath $runScript -WorkingDirectory $sessionRoot -PassThru -NoNewWindow
@@ -506,6 +527,9 @@ finally {
 
     foreach ($name in $sensitiveEnvironmentNames) {
         [Environment]::SetEnvironmentVariable($name, $savedSensitiveEnvironment[$name], 'Process')
+    }
+    foreach ($name in $profileEnvironmentNames) {
+        [Environment]::SetEnvironmentVariable($name, $savedRunnerEnvironment[$name], 'Process')
     }
 
     if (Test-Path -LiteralPath $sessionRoot) {


### PR DESCRIPTION
Reduces the final Antigravity live dependency to one bounded PowerShell operation on a dedicated Linux x64 host/VM/WSL while preserving credential separation.

The bootstrap:
- requires Linux x64, non-root, `gh`, Git, Python and `agy`;
- validates a dedicated Antigravity profile and optionally opens its interactive login flow;
- rejects known persistent GitHub credential files and weak Linux ptrace policy;
- authenticates GitHub CLI only in a temporary `GH_CONFIG_DIR`;
- refuses a competing/stale `factory-antigravity` runner;
- sets only `ANTIGRAVITY_PROFILE_HOME` as a repository variable;
- downloads official GitHub Actions runner v2.337.0 and verifies SHA-256 `70920811a4f8ad4328818682bca5c6469c1c942fab52448868071d0063816613` before extraction;
- registers an `--ephemeral --disableupdate` runner with the required labels;
- materializes issue #115 only when `-RunPilot` is supplied;
- destroys the temporary GitHub CLI credential and clears publication-token environment names before starting the runner;
- runs the runner with a clean temporary HOME/XDG surface;
- waits only for the credential-free provider stage, after which the GitHub-hosted trusted publisher continues durably;
- removes the runner/session directory and restores the caller environment during cleanup.

`validate-factory.yml` now parses this `.ps1` with the real PowerShell parser on every PR/push; it does not execute the bootstrap in CI.

The status document is updated to reflect the already-merged trusted Merge Train/CodeRabbit/Sonar bootstrap work and canonical Antigravity issue #115.

No target auto-merge, production activation, Banco de Notas work or Codex fallback is introduced. The live Antigravity pilot is NOT triggered by this PR.