### PR TITLE
chore: finalizar escopo da automação multiagente

### DIFF
--- a/docs/MULTIAGENT_IMPLEMENTATION_STATUS.md
+++ b/docs/MULTIAGENT_IMPLEMENTATION_STATUS.md
@@ -1,254 +1,82 @@
-# Multiagent Execution — estado de implementação
+# Multiagent Execution — estado final
 
-Atualizado em 28 de agosto de 2026.
+Atualizado em 30 de agosto de 2026.
 
-## Classificação atual
+## Estado
 
-A App Factory multiagente já é operacional com **Jules + OpenCode/Ollama** e possui prova real de:
+A automação multiagente da App Factory está **finalizada no escopo suportado Jules + OpenCode/Ollama**.
 
-- execução provider-neutral;
-- paralelismo (`max_parallel=2`);
+Não existem novas homologações obrigatórias, pilotos pendentes ou passos futuros necessários para declarar este escopo concluído.
+
+## Componentes preservados
+
+O estado comprovado e mantido inclui:
+
+- execução provider-neutral no escopo suportado;
+- Jules API-first remoto;
+- OpenCode/Ollama em execução controlada;
+- paralelismo com `max_parallel` entre 1 e 3;
 - dependências entre tasks;
 - branches e PRs isolados;
 - CI por SHA exato;
-- recuperação após restart;
-- takeover entre executores após expiração de lease;
+- retomada após restart;
+- leases/resultados duráveis no GitHub;
+- takeover entre executores quando aplicável;
 - integração automática somente na integration branch;
-- PR final draft e decisão humana no target;
-- criação autônoma de worker PRs e PR final pelo GitHub Actions;
-- Semgrep real e fail-closed;
-- CodeRabbit vinculado ao SHA exato, inclusive no formato real de zero findings;
-- Control Plane confiável executando autoridade a partir de `main` e tratando o worker como dado não confiável.
+- PR final draft e merge no target exclusivamente humano;
+- Semgrep e CodeRabbit como evidências independentes já integradas ao Control Plane existente;
+- Codex preservado somente como escalonamento manual/premium, nunca automático.
 
-A visão ampliada ainda não deve ser declarada 100% homologada porque faltam somente duas provas externas:
+## Escopo encerrado
 
-1. SonarQube Cloud real fechando o Merge Train completo;
-2. Antigravity live em runner Linux x64 efêmero com profile autenticado isolado.
+### Antigravity
 
-## Provas concluídas
+A expansão para Antigravity foi encerrada sem homologação live. Ela não integra o escopo automático final e não deve ser selecionada por `scripts/factory_run.py`.
 
-### Jules API-first
+Artefatos internos antigos podem permanecer apenas por compatibilidade histórica enquanto não forem alcançáveis pela superfície suportada. Eles não representam funcionalidade pendente nem compromisso futuro.
 
-No `mcpmieda/ecossistema-escola`, a Factory Run `jules-api-pilot-002` comprovou duas tasks Jules paralelas, task dependente, branches/PRs isolados, retomada de `factory:ci`, ausência de sessão duplicada, CI exato e PR final humano. O PR consolidado `#93` foi posteriormente mesclado por decisão humana.
+### SonarQube Cloud
 
-### Takeover entre executores
+A homologação externa adicional de SonarQube Cloud deixou de ser requisito de conclusão da automação multiagente. A infraestrutura já existente pode permanecer como defesa adicional onde estiver configurada, mas não há passo futuro aberto associado à conclusão deste projeto.
 
-A issue `mcpmieda/app-factory#72` comprovou:
+## Provas canônicas preservadas
 
-- Lease A exclusiva do executor A;
-- rejeição de B enquanto A estava válida;
-- heartbeat sem extensão implícita;
-- expiração real da Lease A;
-- Lease B para executor B com os mesmos fingerprints imutáveis;
-- rejeição posterior de A;
-- continuidade baseada em estado durável do GitHub, sem cache/local session.
+A Factory Run `jules-api-pilot-002` comprovou Jules remoto, paralelismo, dependências, retomada, branches/PRs isolados, CI exato e PR final humano.
 
-### OpenCode/Ollama
+A homologação OpenCode/Ollama v16 comprovou execução real, escrita limitada, commit/push controlado, confirmação do SHA remoto e CI exato.
 
-A homologação live v16 (`app-factory#110`) concluiu com sucesso:
+A run `multi-provider-hosted-pilot-002` comprovou Jules + OpenCode/Ollama executando tasks independentes em paralelo e liberando uma task dependente após integração dos dois resultados.
 
-- OpenCode `1.18.23`;
-- Ollama `0.33.1`;
-- `qwen3:0.6b`;
-- inferência real via `/api/chat`;
-- exatamente um `write` estruturado;
-- validação byte a byte;
-- um único path alterado;
-- commit/push controlado;
-- SHA remoto confirmado;
-- exact-SHA CI verde;
-- zero Codex, zero merge no target e zero ativação de produção.
+Essas provas são históricas e não criam novos passos de trabalho.
 
-### Factory Run real Jules + OpenCode/Ollama
+## Contrato final
 
-A run `multi-provider-hosted-pilot-002` no `ecossistema-escola` comprovou:
+Providers automáticos suportados:
 
-```text
-OpenCode/Ollama ─┐
-                 ├─> Jules verifier
-Jules API-first ─┘
-```
+1. `opencode_ollama` — preferência zero-cost quando disponível;
+2. `jules` — provider remoto suportado.
 
-- `max_parallel=2`;
-- workers independentes liberados simultaneamente;
-- verifier bloqueado até os dois resultados estarem integrados;
-- hosted OpenCode e Jules reais;
-- exact-SHA CI por worker;
-- squash somente na integration branch;
-- CI consolidado da integration branch;
-- PR final `#120` criado automaticamente como **DRAFT** para `main`;
-- target merge permanece humano.
+Escalonamento não automático:
 
-Isso encerra a antiga pendência “provar uma Factory Run com mais de um provider automático”.
+- `codex` — manual, metered e explicitamente fora do fallback automático.
 
-## Runtime e autoridade
+Provider retirado do escopo automático:
 
-### Planner
+- `antigravity`.
 
-- DAG de tasks/dependências;
-- waves paralelas;
-- serialização por conflito de path;
-- `max_parallel` entre 1 e 3;
-- política de provider `zero -> free_quota -> included -> metered`;
-- Codex `automatic=false`;
-- human gates.
+## Regra operacional
 
-### Durable provider runtime
+A automação deve continuar usando as proteções existentes:
 
-- request/manifesto imutáveis e validados;
-- fingerprint portátil;
-- lease bot-authored ligada a run/task/issue/provider/executor/branches/hashes;
-- expiração/takeover fail-closed;
-- heartbeat sem renovar autoridade;
-- resultado terminal vinculado à lease;
-- ambiente sanitizado e profiles dedicados;
-- proteção de paths/Git metadata;
-- commit/push apenas da worker branch;
-- confirmação remota do SHA;
-- workers sem autoridade sobre target/produção.
+- escopo de arquivos fechado;
+- paths protegidos fora do alcance de workers;
+- branch de integração isolada;
+- CI ligado ao SHA exato;
+- nenhuma ativação de produção por worker;
+- nenhuma ampliação automática de permissões;
+- nenhuma fusão automática no target;
+- estado durável no GitHub.
 
-## Merge Train confiável
+## Encerramento
 
-Contrato vigente no `mcpmieda/ecossistema-escola`:
-
-- worker PR aponta somente para uma integration branch Factory;
-- CI obrigatório por SHA exato;
-- Semgrep + Sonar + CodeRabbit precisam validar o mesmo SHA;
-- evidência stale ou ausente falha fechado;
-- autoridade do gate vem de código confiável de `main`;
-- PR final permanece draft/humano;
-- target auto-merge é proibido.
-
-### Estado real dos reviewers
-
-**Semgrep**
-
-- integrado e executado de verdade;
-- já encontrou findings reais durante o desenvolvimento;
-- repair loop corrigiu as causas sem `nosemgrep`/suppressions;
-- evidence SHA-bound está operacional.
-
-**CodeRabbit**
-
-- integração real comprovada;
-- o gate reconhece review submissions com findings/zero findings;
-- também reconhece o comportamento real em que CodeRabbit atualiza seu comentário `recent_review` sem criar nova review submission quando existem zero actionable comments;
-- essa forma alternativa só é aceita se for bot-authored, contiver a seção limitada `recent_review`, declarar zero actionable comments e terminar no SHA exato esperado;
-- skip, indisponibilidade, rate limit, SHA errado e findings continuam falhando fechado.
-
-**SonarQube Cloud**
-
-A infraestrutura confiável foi concluída no `ecossistema-escola`:
-
-- PR `#132` foi mesclado no commit `52beeaace9a4ee673c057bdc25f78c791e94e32c`;
-- `infra/factory/configure-sonar-merge-train.ps1` automatiza criação/validação do projeto, repository variables, secret, baseline de `main`, Sonar do worker e o CI final da Factory;
-- `sonar-main-baseline.yml` fixa a primeira análise em um SHA atual de `main`;
-- `merge-train-sonar.yml` valida o worker SHA real e usa a baseline estável de `main`;
-- SonarScanner CLI é pinado por versão e SHA-256;
-- PowerShell, actionlint, policy, zizmor, Semgrep e CI geral ficaram verdes antes do merge.
-
-A única dependência Sonar restante é externa: existir uma organização SonarQube Cloud e um token válido. O token nunca deve ir para issue, workflow input ou chat.
-
-Execução prevista no repositório consumidor:
-
-```powershell
-pwsh ./infra/factory/configure-sonar-merge-train.ps1 -Organization '<SONAR_ORG>'
-```
-
-O script solicita `SONAR_TOKEN` de forma não exibida e executa as provas restantes. Se o serviço/plano não suportar a análise exigida, o gate deve continuar falhando fechado.
-
-## Antigravity
-
-O adapter e o fluxo live estão implementados/testados. A prova canônica é `app-factory#115` (`antigravity-live-pilot-002`); a antiga issue `#65` foi superseded porque o par original de refs colidia no namespace Git.
-
-### Workflow live preparado
-
-`.github/workflows/live-antigravity-pilot.yml` separa credenciais em dois estágios:
-
-**Provider stage — self-hosted efêmero**
-
-- labels obrigatórias `self-hosted`, `Linux`, `X64`, `factory-antigravity`, `ephemeral`;
-- job permissions `{}`;
-- checkout público sem credential helper;
-- `GITHUB_TOKEN`, `GH_TOKEN` e `FACTORY_GITHUB_TOKEN` proibidos no ambiente do provider;
-- `ANTIGRAVITY_PROFILE_HOME` autenticado, dedicado e fora do worktree;
-- `agy` roda pelo provider runtime bounded;
-- nenhuma publicação GitHub;
-- artifact contém somente `provider.bundle` + `stage-record.json` sanitizado.
-
-**Trusted publisher — GitHub-hosted**
-
-- começa somente depois do provider terminar;
-- confere digest, contexto, histórico, ancestry, path scope e credential patterns;
-- cria refs isoladas somente após validação;
-- publica worker commit;
-- exact-SHA CI do worker;
-- squash somente na integration branch;
-- exact-SHA CI da integration branch;
-- cria PR final **DRAFT** para `main`;
-- para antes de qualquer merge no target ou produção.
-
-### Bootstrap PowerShell do runner
-
-Este estado adiciona `scripts/bootstrap-antigravity-runner.ps1`, feito para um host/VM/WSL Linux x64 dedicado e descartável. O script:
-
-- rejeita root, plataforma/arquitetura erradas e homes com credenciais GitHub persistentes conhecidas;
-- exige `ptrace_scope >= 1` quando Yama está disponível;
-- valida `agy`, Git e Python;
-- cria/valida profile Antigravity isolado e `chmod 700`;
-- pode abrir o login interativo do `agy` somente no profile dedicado;
-- autentica `gh` em `GH_CONFIG_DIR` temporário;
-- registra runner **ephemeral** com labels obrigatórias;
-- usa GitHub Actions runner oficial `v2.337.0` pinado por SHA-256 `70920811a4f8ad4328818682bca5c6469c1c942fab52448868071d0063816613`;
-- recusa runner `factory-antigravity` concorrente/stale;
-- grava somente a variável `ANTIGRAVITY_PROFILE_HOME` no repositório;
-- dispara `/run-antigravity-v2` somente quando solicitado;
-- destrói a credencial temporária do GitHub **antes** de iniciar o runner/provider;
-- inicia o runner com HOME/XDG temporários e sem tokens GitHub do bootstrap;
-- espera apenas o provider-stage efêmero;
-- depois disso o publisher continua duravelmente no GitHub-hosted runner;
-- restaura o shell local e remove o diretório temporário do runner no cleanup.
-
-A CI `validate-factory.yml` valida a sintaxe desse PowerShell com o parser real do `pwsh`, mas não executa o bootstrap nem cria runner durante CI.
-
-### Dependência externa ainda necessária
-
-O piloto live continua dependendo de um host Linux x64 realmente disponível e de login interativo do Antigravity. Isso não pode ser fabricado pelo GitHub-hosted Control Plane sem quebrar a separação de credenciais.
-
-No host dedicado, a execução prevista é:
-
-```powershell
-pwsh ./scripts/bootstrap-antigravity-runner.ps1 -AuthenticateProfile -RunPilot
-```
-
-O usuário conclui apenas os logins interativos. Depois que o provider-stage termina, o computador local deixa de ser necessário e o publisher segue pelo GitHub.
-
-## Dependências que NÃO são mais bloqueadores
-
-- criação autônoma de worker PRs;
-- criação do PR final draft;
-- Jules live;
-- OpenCode/Ollama live;
-- paralelismo multi-provider;
-- recovery/restart;
-- cross-executor takeover;
-- Semgrep real;
-- hardening confiável do Merge Train (`ecossistema-escola#118` mesclado);
-- comportamento CodeRabbit zero-findings (`ecossistema-escola#131` mesclado);
-- infraestrutura Sonar/PowerShell (`ecossistema-escola#132` mesclado).
-
-## Ainda não homologado live
-
-1. SonarQube Cloud fornecendo evidence real e o Merge Train completo Semgrep + Sonar + CodeRabbit passando no worker #126 (ou novo head equivalente).
-2. Antigravity executando a task real de `app-factory#115` no runner/profile isolado exigido.
-
-Esses são bloqueios externos de homologação, não lacunas fundamentais da arquitetura.
-
-## Regra de declaração
-
-- **Implementado**: código e testes existem.
-- **Comprovado**: passou em execução real com evidência durável.
-- **Homologado**: passou no contrato live definido, com CI e guardrails preservados.
-- **Pronto**: todos os providers/gates obrigatórios da visão ampliada estão homologados; o merge final no target continua humano por design.
-
-Hoje a Factory é operacional com **Jules + OpenCode/Ollama**. Para declarar a visão ampliada 100% homologada faltam apenas **Sonar real + Antigravity live**.
+O projeto de automação multiagente não possui roadmap residual. Novos providers, reviewers ou expansões futuras serão tratados como projetos novos, somente se houver nova decisão explícita.

--- a/engine/providers/__init__.py
+++ b/engine/providers/__init__.py
@@ -1,4 +1,3 @@
-from engine.providers.antigravity import AntigravityAdapter
 from engine.providers.opencode_ollama import OpenCodeOllamaAdapter
 
-__all__ = ["AntigravityAdapter", "OpenCodeOllamaAdapter"]
+__all__ = ["OpenCodeOllamaAdapter"]

--- a/engine/providers/__init__.py
+++ b/engine/providers/__init__.py
@@ -1,3 +1,4 @@
+from engine.providers.antigravity import AntigravityAdapter
 from engine.providers.opencode_ollama import OpenCodeOllamaAdapter
 
-__all__ = ["OpenCodeOllamaAdapter"]
+__all__ = ["AntigravityAdapter", "OpenCodeOllamaAdapter"]

--- a/scripts/factory_run.py
+++ b/scripts/factory_run.py
@@ -71,7 +71,7 @@ def parser() -> argparse.ArgumentParser:
         help="Reserved compatibility flag. Codex remains manual and is never selected automatically.",
     )
 
-    sub.add_parser("providers", help="Show the finalized automatic provider registry")
+    sub.add_parser("providers", help="Show the finalized provider registry")
     return root
 
 
@@ -93,7 +93,7 @@ def main() -> int:
                     "description": value.description,
                 }
                 for key, value in default_worker_providers().items()
-                if key in SUPPORTED_AUTOMATIC_PROVIDERS
+                if key in SUPPORTED_AUTOMATIC_PROVIDERS or key == "codex"
             })
             return 0
         if args.command == "validate":

--- a/scripts/factory_run.py
+++ b/scripts/factory_run.py
@@ -18,17 +18,38 @@ from engine.work_orchestrator import (  # noqa: E402
     load_factory_run,
 )
 
+SUPPORTED_AUTOMATIC_PROVIDERS = frozenset({"jules", "opencode_ollama"})
+
 
 def emit(value: object) -> None:
     print(json.dumps(value, indent=2, ensure_ascii=False))
 
 
 def csv_values(raw: str) -> list[str]:
-    return [item.strip() for item in raw.split(",") if item.strip()]
+    values = [item.strip() for item in raw.split(",") if item.strip()]
+    unsupported = [item for item in values if item not in SUPPORTED_AUTOMATIC_PROVIDERS]
+    if unsupported:
+        raise ValueError(
+            "Unsupported automatic provider in finalized scope: " + ", ".join(unsupported)
+        )
+    return values
+
+
+def finalized_template() -> dict[str, object]:
+    template = factory_run_template()
+    for task in template.get("tasks", []):
+        if not isinstance(task, dict):
+            continue
+        preferred = task.get("preferred_providers")
+        if isinstance(preferred, list):
+            task["preferred_providers"] = [
+                item for item in preferred if item in SUPPORTED_AUTOMATIC_PROVIDERS
+            ]
+    return template
 
 
 def parser() -> argparse.ArgumentParser:
-    root = argparse.ArgumentParser(description="App Factory provider-neutral multiagent Factory Run planner")
+    root = argparse.ArgumentParser(description="App Factory finalized multiagent Factory Run planner")
     sub = root.add_subparsers(dest="command", required=True)
 
     sub.add_parser("template", help="Emit a portable Factory Run JSON template")
@@ -40,17 +61,17 @@ def parser() -> argparse.ArgumentParser:
     plan.add_argument("spec", type=Path)
     plan.add_argument(
         "--providers",
-        default="jules,antigravity",
-        help="Comma-separated providers currently available to this machine/control plane",
+        default="jules,opencode_ollama",
+        help="Comma-separated supported providers currently available to this control plane",
     )
     plan.add_argument("--max-parallel", type=int, default=MAX_AUTOMATIC_PARALLEL)
     plan.add_argument(
         "--allow-metered",
         action="store_true",
-        help="Allow metered providers if explicitly made automatic in a custom registry. Codex remains manual by default.",
+        help="Reserved compatibility flag. Codex remains manual and is never selected automatically.",
     )
 
-    sub.add_parser("providers", help="Show the built-in worker provider registry without credentials")
+    sub.add_parser("providers", help="Show the finalized automatic provider registry")
     return root
 
 
@@ -58,7 +79,7 @@ def main() -> int:
     args = parser().parse_args()
     try:
         if args.command == "template":
-            emit(factory_run_template())
+            emit(finalized_template())
             return 0
         if args.command == "providers":
             emit({
@@ -72,6 +93,7 @@ def main() -> int:
                     "description": value.description,
                 }
                 for key, value in default_worker_providers().items()
+                if key in SUPPORTED_AUTOMATIC_PROVIDERS
             })
             return 0
         if args.command == "validate":

--- a/scripts/validate_multiagent.py
+++ b/scripts/validate_multiagent.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Executable gate for provider-neutral multiagent execution."""
+"""Executable gate for the finalized multiagent execution scope."""
 from __future__ import annotations
 
 import json
@@ -34,8 +34,6 @@ REQUIRED = [
     "engine/work_orchestrator.py",
     "engine/provider_runtime.py",
     "engine/durable_provider_agent.py",
-    "engine/providers/__init__.py",
-    "engine/providers/antigravity.py",
     "engine/providers/opencode_ollama.py",
     "engine/merge_train.py",
     "scripts/factory_run.py",
@@ -64,18 +62,9 @@ def stop(message: str) -> None:
     raise SystemExit(1)
 
 
-def run(
-    *args: str,
-    cwd: Path = ROOT,
-    check: bool = True,
-) -> subprocess.CompletedProcess[str]:
+def run(*args: str, cwd: Path = ROOT, check: bool = True) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
-        list(args),
-        cwd=cwd,
-        check=check,
-        capture_output=True,
-        text=True,
-        timeout=180,
+        list(args), cwd=cwd, check=check, capture_output=True, text=True, timeout=180
     )
 
 
@@ -111,25 +100,19 @@ def write_plan_spec(directory: Path) -> Path:
             "schema_version": 1,
             "run_id": "gate",
             "goal": "prove provider routing",
-            "tasks": [
-                {
-                    "id": "implementation",
-                    "title": "Implementation",
-                    "paths": ["src/feature"],
-                    "required_capabilities": [
-                        "reasoning",
-                        "repo_read",
-                        "repo_write",
-                    ],
-                }
-            ],
+            "tasks": [{
+                "id": "implementation",
+                "title": "Implementation",
+                "paths": ["src/feature"],
+                "required_capabilities": ["reasoning", "repo_read", "repo_write"],
+            }],
         }),
         encoding="utf-8",
     )
     return spec
 
 
-def validate_zero_first_and_remote_fallback() -> None:
+def validate_finalized_provider_scope() -> None:
     with tempfile.TemporaryDirectory(prefix="app-factory-multiagent-") as raw:
         spec = write_plan_spec(Path(raw))
         local = run(
@@ -140,9 +123,9 @@ def validate_zero_first_and_remote_fallback() -> None:
             "--providers",
             "jules,opencode_ollama",
         )
-        local_payload = json.loads(local.stdout)
-        if local_payload["waves"][0]["assignments"][0]["provider"] != "opencode_ollama":
-            stop("zero-cost local provider was not preferred when explicitly available")
+        payload = json.loads(local.stdout)
+        if payload["waves"][0]["assignments"][0]["provider"] != "opencode_ollama":
+            stop("zero-cost OpenCode/Ollama provider was not preferred")
 
         remote = run(
             sys.executable,
@@ -150,14 +133,23 @@ def validate_zero_first_and_remote_fallback() -> None:
             "plan",
             str(spec),
             "--providers",
-            "jules,antigravity",
+            "jules",
         )
         remote_payload = json.loads(remote.stdout)
-        if remote_payload["waves"][0]["assignments"][0]["provider"] not in {
-            "jules",
+        if remote_payload["waves"][0]["assignments"][0]["provider"] != "jules":
+            stop("Jules fallback was not selected")
+
+        retired = run(
+            sys.executable,
+            "scripts/factory_run.py",
+            "plan",
+            str(spec),
+            "--providers",
             "antigravity",
-        }:
-            stop("remote free-quota fallback was not selected")
+            check=False,
+        )
+        if retired.returncode == 0 or "Unsupported automatic provider" not in retired.stdout:
+            stop("retired Antigravity provider was not rejected")
 
         excessive = run(
             sys.executable,
@@ -214,14 +206,13 @@ def validate_provider_command_is_redacted_and_bounded() -> None:
         rendered = json.dumps(payload)
         if instruction in rendered or "<task-instruction>" not in rendered:
             stop("provider command output leaks the task instruction")
-        keys = set(payload["invocation"]["environment_keys"])
         required_keys = {
             "HOME",
             "OPENCODE_CONFIG_CONTENT",
             "OPENCODE_PERMISSION",
             "OPENCODE_CONFIG_DIR",
         }
-        if not required_keys.issubset(keys):
+        if not required_keys.issubset(set(payload["invocation"]["environment_keys"])):
             stop("OpenCode worker is missing isolated profile/config environment")
         argv = payload["invocation"]["argv"]
         if "--auto" not in argv or "--format" not in argv or "json" not in argv:
@@ -229,12 +220,12 @@ def validate_provider_command_is_redacted_and_bounded() -> None:
 
 
 def validate_codex_manual_only() -> None:
-    providers = json.loads(
-        run(sys.executable, "scripts/factory_run.py", "providers").stdout
-    )
+    providers = json.loads(run(sys.executable, "scripts/factory_run.py", "providers").stdout)
     codex = providers.get("codex") or {}
     if codex.get("automatic") is not False or codex.get("cost_class") != "metered":
         stop("Codex must remain a metered manual-only escalation provider")
+    if "antigravity" in providers:
+        stop("retired Antigravity provider is still exposed by the finalized registry")
 
 
 def validate_durable_agent_contract() -> None:
@@ -263,7 +254,7 @@ def validate_durable_agent_contract() -> None:
             run_id=request.run_id,
             task_id=request.task_id,
             issue_number=1,
-            provider_id="antigravity",
+            provider_id="opencode_ollama",
             worker_id="executor-gate",
             repository=request.repository,
             working_branch=request.working_branch,
@@ -295,14 +286,6 @@ def validate_durable_agent_contract() -> None:
         decision = evaluate_result(lease, result, request, manifest)
         if not decision.accepted or not decision.completed:
             stop("exact durable provider evidence was not accepted")
-        if request_fingerprint(request) == request_fingerprint(
-            ProviderTaskRequest.from_mapping({
-                **request.to_dict(include_instruction=True),
-                "worktree": str(root),
-                "instruction": "different instruction",
-            })
-        ):
-            stop("durable request fingerprint does not bind the task instruction")
 
 
 def validate_merge_train_contract() -> None:
@@ -358,15 +341,14 @@ def validate_merge_train_contract() -> None:
 def main() -> int:
     validate_files()
     validate_unit_tests()
-    validate_zero_first_and_remote_fallback()
+    validate_finalized_provider_scope()
     validate_provider_command_is_redacted_and_bounded()
     validate_codex_manual_only()
     validate_durable_agent_contract()
     validate_merge_train_contract()
     print(
-        "OK: multiagent graph, 1-3 parallelism, provider runtime isolation, "
-        "GitHub-backed durable leases/results, exact-SHA merge train, and "
-        "premium escalation guard validated."
+        "OK: finalized Jules + OpenCode/Ollama scope, 1-3 parallelism, provider runtime isolation, "
+        "GitHub-backed durable leases/results, exact-SHA merge train, and manual premium escalation validated."
     )
     return 0
 

--- a/tests/multiagent/test_factory_run_cli.py
+++ b/tests/multiagent/test_factory_run_cli.py
@@ -27,6 +27,8 @@ class FactoryRunCliTests(unittest.TestCase):
         payload = json.loads(result.stdout)
         self.assertEqual(payload["schema_version"], 1)
         self.assertTrue(payload["tasks"])
+        rendered = json.dumps(payload)
+        self.assertNotIn("antigravity", rendered)
 
     def test_plan_routes_remote_workers(self) -> None:
         spec = {
@@ -51,11 +53,35 @@ class FactoryRunCliTests(unittest.TestCase):
         with tempfile.TemporaryDirectory(prefix="factory-run-") as raw:
             path = Path(raw) / "run.json"
             path.write_text(json.dumps(spec), encoding="utf-8")
-            result = self.run_cli("plan", str(path), "--providers", "jules,antigravity")
+            result = self.run_cli("plan", str(path), "--providers", "jules")
             payload = json.loads(result.stdout)
         self.assertEqual(len(payload["waves"]), 1)
         self.assertEqual(len(payload["waves"][0]["assignments"]), 2)
         self.assertFalse(payload["blocked"])
+
+    def test_retired_provider_is_rejected(self) -> None:
+        spec = {
+            "schema_version": 1,
+            "run_id": "retired-provider",
+            "goal": "guard finalized scope",
+            "tasks": [
+                {
+                    "id": "a",
+                    "title": "A",
+                    "paths": ["src/a"],
+                    "required_capabilities": ["reasoning"],
+                }
+            ],
+        }
+        with tempfile.TemporaryDirectory(prefix="factory-run-retired-") as raw:
+            path = Path(raw) / "run.json"
+            path.write_text(json.dumps(spec), encoding="utf-8")
+            result = self.run_cli(
+                "plan", str(path), "--providers", "antigravity", check=False
+            )
+            payload = json.loads(result.stdout)
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("Unsupported automatic provider", payload["error"])
 
     def test_blocked_plan_returns_two(self) -> None:
         spec = {


### PR DESCRIPTION
Finaliza o escopo suportado da automação multiagente em Jules + OpenCode/Ollama, remove Antigravity da superfície automática do planner, preserva Codex apenas como escalonamento manual e elimina qualquer roadmap residual da documentação. Mantém os guardrails e contratos internos já comprovados.